### PR TITLE
Local time refactor

### DIFF
--- a/src/datetimeformat-ponyfill.ts
+++ b/src/datetimeformat-ponyfill.ts
@@ -1,0 +1,57 @@
+import {strftime} from './strftime.js'
+export class DateTimeFormat implements Intl.DateTimeFormat {
+  #options: Intl.ResolvedDateTimeFormatOptions
+
+  constructor(locale: string, options: Intl.DateTimeFormatOptions) {
+    this.#options = {
+      locale: 'en',
+      calendar: 'gregory',
+      numberingSystem: 'latn',
+      weekday: options.weekday,
+      minute: options.minute,
+      hour: options.hour,
+      day: options.day ?? '2-digit',
+      month: options.month ?? '2-digit',
+      year: options.year ?? 'numeric',
+      timeZone: options.timeZone ?? ''
+    }
+  }
+
+  formatToParts() {
+    return []
+  }
+
+  resolvedOptions() {
+    return this.#options
+  }
+
+  // Simplified "en" RelativeTimeFormat.format function
+  //
+  // Values should roughly match
+  //   new Intl.RelativeTimeFormat('en', {numeric: 'auto'}).format(value, unit)
+  //
+  format(value: number | Date): string {
+    let str = ''
+    const {weekday, month, day, year, hour, minute, second} = this.resolvedOptions()
+    if (weekday === 'long') str += '%A'
+    if (weekday === 'short') str += '%a'
+    if (weekday === 'narrow') str += '%a'
+    if (month === 'numeric') str += ' %m'
+    if (month === '2-digit') str += ' %m'
+    if (month === 'long') str += ' %B'
+    if (month === 'short') str += ' %b'
+    if (month === 'narrow') str += ' %b'
+    if (day === 'numeric') str += ' %e'
+    if (day === '2-digit') str += ' %d'
+    if (year === 'numeric') str += ', %Y'
+    if (year === '2-digit') str += ', %y'
+    if (hour === 'numeric') str += ' %H'
+    if (hour === '2-digit') str += ' %H'
+    if (minute === 'numeric') str += `${hour ? ':' : ''}%M`
+    if (minute === '2-digit') str += `${hour ? ':' : ''}%M`
+    if (second === 'numeric') str += `${hour ? ':' : ''}%S`
+    if (second === '2-digit') str += `${hour || minute ? ':' : ''}%S`
+
+    return strftime(new Date(value), str.trim())
+  }
+}

--- a/src/local-time-element.ts
+++ b/src/local-time-element.ts
@@ -1,126 +1,31 @@
-import {makeFormatter, localeFromElement, isDayFirst} from './utils.js'
-import {strftime} from './strftime.js'
 import RelativeTimeElement from './relative-time-element.js'
 
-const formatters = new WeakMap<Element, ReturnType<typeof makeFormatter>>()
-
 export default class LocalTimeElement extends RelativeTimeElement {
-  attributeChangedCallback(attrName: string): void {
-    if (attrName === 'hour' || attrName === 'minute' || attrName === 'second' || attrName === 'time-zone-name') {
-      formatters.delete(this)
-    }
-    super.attributeChangedCallback(attrName)
+  get prefix() {
+    return ''
   }
 
-  // Formats the element's date, in the user's current locale, according to
-  // the formatting attribute values. Values are not passed straight through to
-  // an Intl.DateTimeFormat instance so that weekday and month names are always
-  // displayed in English, for now.
-  //
-  // Supported attributes are:
-  //
-  //   weekday - "short", "long"
-  //   year    - "numeric", "2-digit"
-  //   month   - "short", "long"
-  //   day     - "numeric", "2-digit"
-  //   hour    - "numeric", "2-digit"
-  //   minute  - "numeric", "2-digit"
-  //   second  - "numeric", "2-digit"
-  //
-  // Returns a formatted time String.
-  getFormattedDate(): string | undefined {
-    const d = this.date
-    if (!d) return
-
-    const date = formatDate(this, d) || ''
-    const time = formatTime(this, d) || ''
-    return `${date} ${time}`.trim()
+  get format() {
+    if (super.format.includes('%')) return super.format
+    if (!this.day && !this.month && !this.year && !this.timeZoneName && !this.hour && !this.minute) return ''
+    return 'auto'
   }
-}
 
-// Private: Format a date according to the `weekday`, `day`, `month`,
-// and `year` attribute values.
-//
-// This doesn't use Intl.DateTimeFormat to avoid creating text in the user's
-// language when the majority of the surrounding text is in English. There's
-// currently no way to separate the language from the format in Intl.
-//
-// el - The local-time element to format.
-//
-// Returns a date String or null if no date formats are provided.
-function formatDate(el: Element, date: Date) {
-  // map attribute values to strftime
-  const props: {[key: string]: {[key: string]: string}} = {
-    weekday: {
-      short: '%a',
-      long: '%A'
-    },
-    day: {
-      numeric: '%e',
-      '2-digit': '%d'
-    },
-    month: {
-      short: '%b',
-      long: '%B'
-    },
-    year: {
-      numeric: '%Y',
-      '2-digit': '%y'
+  get day() {
+    const day = this.getAttribute('day')
+    if (day === 'numeric' || day === '2-digit') return day
+  }
+
+  get month() {
+    const month = this.getAttribute('month')
+    if (month === 'numeric' || month === '2-digit' || month === 'short' || month === 'long' || month === 'narrow') {
+      return month
     }
   }
 
-  // build a strftime format string
-  let format = isDayFirst() ? 'weekday day month year' : 'weekday month day, year'
-  for (const prop in props) {
-    const value = props[prop][el.getAttribute(prop) || '']
-    format = format.replace(prop, value || '')
-  }
-
-  // clean up year separator comma
-  format = format.replace(/(\s,)|(,\s$)/, '')
-
-  // squeeze spaces from final string
-  return strftime(date, format).replace(/\s+/, ' ').trim()
-}
-
-// Private: Format a time according to the `hour`, `minute`, and `second`
-// attribute values.
-//
-// el - The local-time element to format.
-//
-// Returns a time String or null if no time formats are provided.
-function formatTime(el: HTMLElement, date: Date) {
-  const options: Intl.DateTimeFormatOptions = {}
-
-  // retrieve format settings from attributes
-  const hour = el.getAttribute('hour')
-  if (hour === 'numeric' || hour === '2-digit') options.hour = hour
-  const minute = el.getAttribute('minute')
-  if (minute === 'numeric' || minute === '2-digit') options.minute = minute
-  const second = el.getAttribute('second')
-  if (second === 'numeric' || second === '2-digit') options.second = second
-  const tz = el.getAttribute('time-zone-name')
-  if (tz === 'short' || tz === 'long') options.timeZoneName = tz
-
-  // No time format attributes provided.
-  if (Object.keys(options).length === 0) {
-    return
-  }
-
-  let factory = formatters.get(el)
-  if (!factory) {
-    factory = makeFormatter(options)
-    formatters.set(el, factory)
-  }
-
-  const formatter = factory(localeFromElement(el))
-  if (formatter) {
-    // locale-aware formatting of 24 or 12 hour times
-    return formatter.format(date)
-  } else {
-    // fall back to strftime for non-Intl browsers
-    const timef = options.second ? '%H:%M:%S' : '%H:%M'
-    return strftime(date, timef)
+  get year() {
+    const year = this.getAttribute('year')
+    if (year === 'numeric' || year === '2-digit') return year
   }
 }
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -1,8 +1,12 @@
 import type {Tense, Format} from './relative-time.js'
 import RelativeTime from './relative-time.js'
+import {DateTimeFormat as DateTimeFormatPonyFill} from './datetimeformat-ponyfill.js'
 import {makeFormatter, localeFromElement} from './utils.js'
 import {isDuration, withinDuration} from './duration.js'
 import {strftime} from './strftime.js'
+
+const supportsIntlDatetime = 'Intl' in window && 'RelativeTimeFormat'
+const DateTimeFormat = supportsIntlDatetime ? Intl.DateTimeFormat : DateTimeFormatPonyFill
 
 export class RelativeTimeUpdatedEvent extends Event {
   constructor(public oldText: string, public newText: string, public oldTitle: string, public newTitle: string) {
@@ -113,18 +117,15 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
     if (tense === 'future' || (tense === 'auto' && inFuture && within)) {
       return micro ? relativeTime.microTimeUntil() : relativeTime.timeUntil()
     }
-    if ('Intl' in window && 'DateTimeFormat' in Intl) {
-      const formatter = new Intl.DateTimeFormat(localeFromElement(this), {
-        minute: this.minute,
-        hour: this.hour,
-        day: this.day,
-        month: this.month,
-        year: this.year,
-        timeZoneName: this.timeZoneName
-      })
-      return `${this.prefix} ${formatter.format(date)}`.trim()
-    }
-    return `${this.prefix} ${strftime(date, `%b %e${this.year === 'numeric' ? ', %Y' : ''}`)}`.trim()
+    const formatter = new DateTimeFormat(localeFromElement(this), {
+      minute: this.minute,
+      hour: this.hour,
+      day: this.day,
+      month: this.month,
+      year: this.year,
+      timeZoneName: this.timeZoneName
+    })
+    return `${this.prefix} ${formatter.format(date)}`.trim()
   }
 
   get minute() {


### PR DESCRIPTION
This PR introduces a `DateTimeFormat` ponyfill, which allows us to drop it in place of `Intl.DateTimeFormat`. This then allowed a larger refactor where we can drop parts of the codebase where we emulated `DateTimeFormat` behavior using strftime. Instead, the ponyfill does that and the `relative-time` and `local-time` code can be greatly simplified.

I think in the major version release, we should drop both the `DateTimeFormat` and `RelativeTime` ponyfills as these are very well supported in evergreen browsers. (`DateTimeFormat` works back to IE11 & Safari 10, while `RelativeTime` works back to Safari 14)