### PR TITLE
add tests for ponyfills

### DIFF
--- a/src/datetimeformat-ponyfill.ts
+++ b/src/datetimeformat-ponyfill.ts
@@ -10,10 +10,15 @@ export class DateTimeFormat implements Intl.DateTimeFormat {
       weekday: options.weekday,
       minute: options.minute,
       hour: options.hour,
-      day: options.day ?? '2-digit',
-      month: options.month ?? '2-digit',
-      year: options.year ?? 'numeric',
+      day: options.day,
+      month: options.month,
+      year: options.year,
       timeZone: options.timeZone ?? ''
+    }
+    if (!Object.keys(options).length) {
+      this.#options.day = '2-digit'
+      this.#options.month = '2-digit'
+      this.#options.year = 'numeric'
     }
   }
 
@@ -36,21 +41,26 @@ export class DateTimeFormat implements Intl.DateTimeFormat {
     if (weekday === 'long') str += '%A'
     if (weekday === 'short') str += '%a'
     if (weekday === 'narrow') str += '%a'
-    if (month === 'numeric') str += ' %m'
-    if (month === '2-digit') str += ' %m'
-    if (month === 'long') str += ' %B'
-    if (month === 'short') str += ' %b'
-    if (month === 'narrow') str += ' %b'
-    if (day === 'numeric') str += ' %e'
-    if (day === '2-digit') str += ' %d'
-    if (year === 'numeric') str += ', %Y'
-    if (year === '2-digit') str += ', %y'
-    if (hour === 'numeric') str += ' %H'
-    if (hour === '2-digit') str += ' %H'
+    if ((month === 'numeric' || month === '2-digit') && day && year) {
+      str += `${weekday ? ', ' : ''}%m/%d/%${year === '2-digit' ? 'y' : 'Y'}`
+    } else {
+      if (month === 'numeric') str += `${weekday ? ', ' : ''}%m`
+      if (month === '2-digit') str += `${weekday ? ', ' : ''}%m`
+      if (month === 'long') str += `${weekday ? ', ' : ''}%B`
+      if (month === 'short') str += `${weekday ? ', ' : ''}%b`
+      if (month === 'narrow') str += `${weekday ? ', ' : ''}%b`
+      if (day === 'numeric') str += ' %e'
+      if (day === '2-digit') str += ' %d'
+      if (year === 'numeric') str += ', %Y'
+      if (year === '2-digit') str += ', %y'
+    }
+    if (hour === 'numeric') str += `${str ? ',' : ''}%l`
+    if (hour === '2-digit') str += `${str ? ', ' : ''}%H`
     if (minute === 'numeric') str += `${hour ? ':' : ''}%M`
     if (minute === '2-digit') str += `${hour ? ':' : ''}%M`
     if (second === 'numeric') str += `${hour ? ':' : ''}%S`
     if (second === '2-digit') str += `${hour || minute ? ':' : ''}%S`
+    if (hour) str += ' %p'
 
     return strftime(new Date(value), str.trim())
   }

--- a/src/relative-time-ponyfill.ts
+++ b/src/relative-time-ponyfill.ts
@@ -1,4 +1,4 @@
-export class RelativeTime implements Intl.RelativeTimeFormat {
+export class RelativeTimeFormat implements Intl.RelativeTimeFormat {
   formatToParts() {
     return []
   }

--- a/src/relative-time.ts
+++ b/src/relative-time.ts
@@ -1,4 +1,4 @@
-import {RelativeTime as RelativeTimePonyfill} from './relative-time-ponyfill.js'
+import {RelativeTimeFormat} from './relative-time-ponyfill.js'
 
 export type Format = 'auto' | 'micro' | string
 export type Tense = 'auto' | 'past' | 'future'
@@ -134,6 +134,6 @@ function formatRelativeTime(locale: string, value: number, unit: Intl.RelativeTi
       }
     }
   }
-  formatter ||= new RelativeTimePonyfill()
+  formatter ||= new RelativeTimeFormat()
   return formatter.format(value, unit)
 }

--- a/test/datetimeformat-ponyfill.ts
+++ b/test/datetimeformat-ponyfill.ts
@@ -1,0 +1,26 @@
+import {assert} from '@open-wc/testing'
+import {DateTimeFormat} from '../src/datetimeformat-ponyfill.js'
+
+suite('datetimeformat ponyfill', function () {
+  const tests = new Set([
+    {},
+    {month: '2-digit', day: '2-digit', year: '2-digit'},
+    {month: 'short', day: '2-digit'},
+    {month: 'long', day: '2-digit', year: 'numeric'},
+    {month: 'short', day: 'numeric', year: 'numeric'},
+    {weekday: 'long', month: 'long', day: '2-digit', year: 'numeric'},
+    {weekday: 'long', month: '2-digit', day: '2-digit', year: 'numeric'},
+    {weekday: 'long', month: 'short', day: '2-digit', year: 'numeric'},
+    {weekday: 'long', month: 'short', day: '2-digit', year: 'numeric', hour: 'numeric'},
+    {weekday: 'long', month: 'short', day: '2-digit', year: 'numeric', hour: 'numeric', minute: 'numeric'}
+  ])
+
+  for (const {date = new Date('2022-10-24T14:46:00.000Z'), ...opts} of tests) {
+    const real = new Intl.DateTimeFormat('en', opts)
+    test(`DateTimeFormat('en', ${JSON.stringify(opts)}).format(${date.toISOString()}) === ${real.format(
+      date
+    )}`, function () {
+      assert.equal(new DateTimeFormat('en', opts).format(date), real.format(date))
+    })
+  }
+})

--- a/test/relativetimeformat-ponyfill.ts
+++ b/test/relativetimeformat-ponyfill.ts
@@ -1,0 +1,62 @@
+import {assert} from '@open-wc/testing'
+import {RelativeTimeFormat} from '../src/relative-time-ponyfill.js'
+
+suite('relativetime ponyfill', function () {
+  const tests = new Set([
+    [0, 'second'],
+    [1, 'second'],
+    [30, 'second'],
+    [60, 'second'],
+    [65, 'second'],
+    [-1, 'second'],
+    [-30, 'second'],
+    [-60, 'second'],
+    [-65, 'second'],
+    [0, 'day'],
+    [1, 'day'],
+    [15, 'day'],
+    [30, 'day'],
+    [35, 'day'],
+    [-1, 'day'],
+    [-15, 'day'],
+    [-30, 'day'],
+    [-35, 'day'],
+    [0, 'week'],
+    [1, 'week'],
+    [2, 'week'],
+    [8, 'week'],
+    [55, 'week'],
+    [-1, 'week'],
+    [-2, 'week'],
+    [-8, 'week'],
+    [-55, 'week'],
+    [-5, 'week'],
+    [0, 'month'],
+    [1, 'month'],
+    [5, 'month'],
+    [12, 'month'],
+    [18, 'month'],
+    [-1, 'month'],
+    [-5, 'month'],
+    [-12, 'month'],
+    [-18, 'month'],
+    [0, 'year'],
+    [1, 'year'],
+    [5, 'year'],
+    [12, 'year'],
+    [18, 'year'],
+    [-1, 'year'],
+    [-5, 'year'],
+    [-12, 'year'],
+    [-18, 'year']
+  ])
+
+  for (const opts of tests) {
+    const real = new Intl.RelativeTimeFormat('en', {numeric: 'auto'})
+    test(`RelativeTimeFormat('en', {numeric: 'auto'}).format(${JSON.stringify(opts)}) === ${real.format(
+      ...opts
+    )}`, function () {
+      assert.equal(new RelativeTimeFormat('en', {numeric: 'auto'}).format(...opts), real.format(...opts))
+    })
+  }
+})


### PR DESCRIPTION
In #194 I forgot to add tests, which I had written. I've written some more now for both ponyfills so that they align with what the real Intl objects do (at least for `'en'` locale :smile:)