### PR TITLE
refactor relative-time to remove RelativeTimeFormat

### DIFF
--- a/src/relative-time.ts
+++ b/src/relative-time.ts
@@ -1,18 +1,13 @@
-import {RelativeTimeFormat} from './relative-time-ponyfill.js'
-
-export type Format = 'auto' | 'micro' | string
-export type Tense = 'auto' | 'past' | 'future'
+export type Unit = 'second' | 'minute' | 'hour' | 'day' | 'month' | 'year'
 
 export default class RelativeTime {
   date: Date
-  locale: string
 
-  constructor(date: Date, locale: string) {
+  constructor(date: Date) {
     this.date = date
-    this.locale = locale
   }
 
-  timeAgo(): string | undefined {
+  timeAgo(): [number, Unit] {
     const ms = new Date().getTime() - this.date.getTime()
     const sec = Math.round(ms / 1000)
     const min = Math.round(sec / 60)
@@ -21,31 +16,31 @@ export default class RelativeTime {
     const month = Math.round(day / 30)
     const year = Math.round(month / 12)
     if (ms < 0) {
-      return formatRelativeTime(this.locale, 0, 'second')
+      return [0, 'second']
     } else if (sec < 10) {
-      return formatRelativeTime(this.locale, 0, 'second')
+      return [0, 'second']
     } else if (sec < 45) {
-      return formatRelativeTime(this.locale, -sec, 'second')
+      return [-sec, 'second']
     } else if (sec < 90) {
-      return formatRelativeTime(this.locale, -min, 'minute')
+      return [-min, 'minute']
     } else if (min < 45) {
-      return formatRelativeTime(this.locale, -min, 'minute')
+      return [-min, 'minute']
     } else if (min < 90) {
-      return formatRelativeTime(this.locale, -hr, 'hour')
+      return [-hr, 'hour']
     } else if (hr < 24) {
-      return formatRelativeTime(this.locale, -hr, 'hour')
+      return [-hr, 'hour']
     } else if (hr < 36) {
-      return formatRelativeTime(this.locale, -day, 'day')
+      return [-day, 'day']
     } else if (day < 30) {
-      return formatRelativeTime(this.locale, -day, 'day')
+      return [-day, 'day']
     } else if (month < 18) {
-      return formatRelativeTime(this.locale, -month, 'month')
+      return [-month, 'month']
     } else {
-      return formatRelativeTime(this.locale, -year, 'year')
+      return [-year, 'year']
     }
   }
 
-  microTimeAgo(): string {
+  microTimeAgo(): [number, Unit] {
     const ms = new Date().getTime() - this.date.getTime()
     const sec = Math.round(ms / 1000)
     const min = Math.round(sec / 60)
@@ -54,19 +49,19 @@ export default class RelativeTime {
     const month = Math.round(day / 30)
     const year = Math.round(month / 12)
     if (min < 1) {
-      return '1m'
+      return [1, 'minute']
     } else if (min < 60) {
-      return `${min}m`
+      return [min, 'minute']
     } else if (hr < 24) {
-      return `${hr}h`
+      return [hr, 'hour']
     } else if (day < 365) {
-      return `${day}d`
+      return [day, 'day']
     } else {
-      return `${year}y`
+      return [year, 'year']
     }
   }
 
-  timeUntil(): string {
+  timeUntil(): [number, Unit] {
     const ms = this.date.getTime() - new Date().getTime()
     const sec = Math.round(ms / 1000)
     const min = Math.round(sec / 60)
@@ -75,33 +70,33 @@ export default class RelativeTime {
     const month = Math.round(day / 30)
     const year = Math.round(month / 12)
     if (month >= 18) {
-      return formatRelativeTime(this.locale, year, 'year')
+      return [year, 'year']
     } else if (month >= 12) {
-      return formatRelativeTime(this.locale, year, 'year')
+      return [year, 'year']
     } else if (day >= 45) {
-      return formatRelativeTime(this.locale, month, 'month')
+      return [month, 'month']
     } else if (day >= 30) {
-      return formatRelativeTime(this.locale, month, 'month')
+      return [month, 'month']
     } else if (hr >= 36) {
-      return formatRelativeTime(this.locale, day, 'day')
+      return [day, 'day']
     } else if (hr >= 24) {
-      return formatRelativeTime(this.locale, day, 'day')
+      return [day, 'day']
     } else if (min >= 90) {
-      return formatRelativeTime(this.locale, hr, 'hour')
+      return [hr, 'hour']
     } else if (min >= 45) {
-      return formatRelativeTime(this.locale, hr, 'hour')
+      return [hr, 'hour']
     } else if (sec >= 90) {
-      return formatRelativeTime(this.locale, min, 'minute')
+      return [min, 'minute']
     } else if (sec >= 45) {
-      return formatRelativeTime(this.locale, min, 'minute')
+      return [min, 'minute']
     } else if (sec >= 10) {
-      return formatRelativeTime(this.locale, sec, 'second')
+      return [sec, 'second']
     } else {
-      return formatRelativeTime(this.locale, 0, 'second')
+      return [0, 'second']
     }
   }
 
-  microTimeUntil(): string {
+  microTimeUntil(): [number, Unit] {
     const ms = this.date.getTime() - new Date().getTime()
     const sec = Math.round(ms / 1000)
     const min = Math.round(sec / 60)
@@ -110,30 +105,15 @@ export default class RelativeTime {
     const month = Math.round(day / 30)
     const year = Math.round(month / 12)
     if (day >= 365) {
-      return `${year}y`
+      return [year, 'year']
     } else if (hr >= 24) {
-      return `${day}d`
+      return [day, 'day']
     } else if (min >= 60) {
-      return `${hr}h`
+      return [hr, 'hour']
     } else if (min > 1) {
-      return `${min}m`
+      return [min, 'minute']
     } else {
-      return '1m'
+      return [1, 'minute']
     }
   }
-}
-
-function formatRelativeTime(locale: string, value: number, unit: Intl.RelativeTimeFormatUnit): string {
-  let formatter
-  if ('Intl' in window && 'RelativeTimeFormat' in window.Intl) {
-    try {
-      formatter = new Intl.RelativeTimeFormat(locale, {numeric: 'auto'})
-    } catch (e) {
-      if (!(e instanceof RangeError)) {
-        throw e
-      }
-    }
-  }
-  formatter ||= new RelativeTimeFormat()
-  return formatter.format(value, unit)
 }

--- a/src/time-ago-element.ts
+++ b/src/time-ago-element.ts
@@ -1,4 +1,4 @@
-import {Tense} from './relative-time.js'
+import type {Tense} from './relative-time-element.js'
 import RelativeTimeElement from './relative-time-element.js'
 
 export default class TimeAgoElement extends RelativeTimeElement {

--- a/src/time-until-element.ts
+++ b/src/time-until-element.ts
@@ -1,4 +1,4 @@
-import {Tense} from './relative-time.js'
+import type {Tense} from './relative-time-element.js'
 import RelativeTimeElement from './relative-time-element.js'
 
 export default class TimeUntilElement extends RelativeTimeElement {


### PR DESCRIPTION
This extracts out the coupling of `RelativeTimeFormat` from our `RelativeTime` class - which now instead returns a tuple of `number, Unit`, reflecting just the rounded unit of time that should be rendered. This allows us to subsequently refactor the `RelativeTime` class closer to the proposed web platform primitive Temporal.Duration, which will come in a follow up PR :smile: 