### PR TITLE
avoid eagerly calling this.update()

### DIFF
--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1,5 +1,5 @@
 import {assert} from '@open-wc/testing'
-import '../src/relative-time-element.ts'
+import RelativeTimeElement from '../src/relative-time-element.ts'
 
 suite('relative-time', function () {
   let dateNow
@@ -36,6 +36,26 @@ suite('relative-time', function () {
       Date = dateNow
       dateNow = null
     }
+  })
+
+  test('does not call update() frequently with attributeChangedCallback', () => {
+    let counter = 0
+    const el = document.createElement('relative-time')
+    el.update = function () {
+      counter += 1
+      return RelativeTimeElement.prototype.update.call(this)
+    }
+    assert.equal(counter, 0)
+    el.setAttribute('datetime', new Date().toISOString())
+    assert.equal(counter, 1)
+    el.setAttribute('datetime', el.getAttribute('datetime'))
+    assert.equal(counter, 1)
+    el.disconnectedCallback()
+    assert.equal(counter, 1)
+    el.setAttribute('title', 'custom')
+    assert.equal(counter, 1)
+    el.setAttribute('title', 'another custom')
+    assert.equal(counter, 1)
   })
 
   test("doesn't error when no date is provided", function () {


### PR DESCRIPTION
`update()` is getting a bit too eagerly called in the latest version, which is causing many time elements on the page to stack overflow. This mitigates that in a few ways:

 - Ensure if the `attributeChangedCallback` is called with the same value, that it doesn't call `update`.
 - Ensure that if the `title` attribute changes, it doesn't lead to an `update`.
 - Ensure that when an element gets `unobserve`d, that it doesn't trigger an update of all elements (as there's no point in updating eagerly here - the current `setTimeout` could already be eager if the element being unobserved is the latest element).
 - Ensure that when an element _does_ get `observe`d, that it doesn't immediately trigger an update. Rather, it determines if it _should_ update sooner than the next scheduled update, and if so it'll reschedule the update to occur sooner.