### PR TITLE
ensure invalid dates fallback to lightdom textcontent

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -331,6 +331,9 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
     newText = this.getFormattedDate(now) || ''
     if (newText) {
       this.#renderRoot.textContent = newText
+    } else if (this.shadowRoot === this.#renderRoot && this.textContent) {
+      // Ensure invalid dates fall back to lightDOM text content
+      this.#renderRoot.textContent = this.textContent
     }
 
     if (newText !== oldText || newTitle !== oldTitle) {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -58,6 +58,13 @@ suite('relative-time', function () {
     assert.equal(counter, 1)
   })
 
+  test('shadowDOM reflects textContent with invalid date', () => {
+    const el = document.createElement('relative-time')
+    el.textContent = 'A date string'
+    el.setAttribute('datetime', 'Invalid')
+    if (el.shadowRoot) assert.equal(el.shadowRoot.textContent, el.textContent)
+  })
+
   test('updates the time automatically when it is a few seconds ago', async function () {
     // eslint-disable-next-line @typescript-eslint/no-invalid-this
     this.timeout(3000)


### PR DESCRIPTION
We've encountered a regression that entered into `<relative-time>` when it comes to invalid usage. Prior to using shadowdom, invalid usage would not change the text content, which means it would be left with whatever was server rendered. When introducing the shadowdom, we implicitly do not render whatever textContent is present in the lightdom, and so if an invalid use of the element occurs, the shadowdom will be empty, in other words nothing will be rendered.

In order to maintain compatibility, this PR introduces a fallback behaviour where if `getFomrattedDate()` is empty, it will intentionally copy over the lightdom textContent into the shadowdom, emulating the old behaviour. 