### PR TITLE
use `Intl` without window prefix

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -4,10 +4,10 @@ import {RelativeTimeFormat as RelativeTimeFormatPonyfill} from './relative-time-
 import {isDuration, withinDuration} from './duration.js'
 import {strftime} from './strftime.js'
 
-const supportsIntlDatetime = 'Intl' in window && 'DateTimeFormat' in Intl
+const supportsIntlDatetime = typeof Intl !== 'undefined' && 'DateTimeFormat' in Intl
 const DateTimeFormat = supportsIntlDatetime ? Intl.DateTimeFormat : DateTimeFormatPonyFill
 
-const supportsIntlRelativeTime = 'Intl' in window && 'RelativeTimeFormat' in Intl
+const supportsIntlRelativeTime = typeof Intl !== 'undefined' && 'RelativeTimeFormat' in Intl
 const RelativeTimeFormat = supportsIntlRelativeTime ? Intl.RelativeTimeFormat : RelativeTimeFormatPonyfill
 
 export type Format = 'auto' | 'micro' | 'elapsed' | string

--- a/src/strftime.ts
+++ b/src/strftime.ts
@@ -1,4 +1,4 @@
-const supportsIntlDatetime = 'Intl' in window && 'DateTimeFormat' in Intl
+const supportsIntlDatetime = typeof Intl !== 'undefined' && 'DateTimeFormat' in Intl
 
 const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 const months = [


### PR DESCRIPTION
In order for this to be usable in Primer React, we need to remove the references to `window` which the gatsby build doesn't seem to like. Lucky that's easy enough.

https://github.com/primer/react/actions/runs/3525178884/jobs/5911569573

This PR changes the `'Intl' in window && 'XX' in Intl` checks to instead be `typeof Intl !== 'undefined' && 'XX' in Intl`. This is pretty much identical logic, but avoids referencing the `window` global and as such this code can be loaded in NodeJS without error.