### PR TITLE
add `define` export for custom element registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,18 @@
     "dist",
     "custom-elements.json"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./define": "./dist/index.js",
+    "./relative-time": "./dist/relative-time-element.js",
+    "./relative-time/define": "./dist/relative-time-element-define.js",
+    "./local-time": "./dist/local-time-element.js",
+    "./local-time/define": "./dist/local-time-element-define.js",
+    "./time-ago": "./dist/time-ago-element.js",
+    "./time-ago/define": "./dist/time-ago-element-define.js",
+    "./time-until": "./dist/time-until-element.js",
+    "./time-until/define": "./dist/time-until-element-define.js"
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .js,.ts && tsc --noEmit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,50 +1,6 @@
-import LocalTimeElement from './local-time-element.js'
-import RelativeTimeElement from './relative-time-element.js'
-import TimeAgoElement from './time-ago-element.js'
-import TimeUntilElement from './time-until-element.js'
-
-const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
-try {
-  customElements.define('relative-time', RelativeTimeElement)
-  root.RelativeTimeElement = RelativeTimeElement
-} catch (e: unknown) {
-  if (!(e instanceof DOMException && e.name === 'NotSupportedError') && !(e instanceof ReferenceError)) throw e
-}
-
-try {
-  customElements.define('local-time', LocalTimeElement)
-  root.LocalTimeElement = LocalTimeElement
-} catch (e: unknown) {
-  if (!(e instanceof DOMException && e.name === 'NotSupportedError') && !(e instanceof ReferenceError)) throw e
-}
-
-try {
-  customElements.define('time-ago', TimeAgoElement)
-  root.TimeAgoElement = TimeAgoElement
-} catch (e: unknown) {
-  if (!(e instanceof DOMException && e.name === 'NotSupportedError') && !(e instanceof ReferenceError)) throw e
-}
-
-try {
-  customElements.define('time-until', TimeUntilElement)
-  root.TimeUntilElement = TimeUntilElement
-} catch (e: unknown) {
-  if (!(e instanceof DOMException && e.name === 'NotSupportedError') && !(e instanceof ReferenceError)) throw e
-}
-
-declare global {
-  interface Window {
-    RelativeTimeElement: typeof RelativeTimeElement
-    LocalTimeElement: typeof LocalTimeElement
-    TimeAgoElement: typeof TimeAgoElement
-    TimeUntilElement: typeof TimeUntilElement
-  }
-  interface HTMLElementTagNameMap {
-    'relative-time': RelativeTimeElement
-    'local-time': LocalTimeElement
-    'time-ago': TimeAgoElement
-    'time-until': TimeUntilElement
-  }
-}
+import LocalTimeElement from './local-time-element-define.js'
+import RelativeTimeElement from './relative-time-element-define.js'
+import TimeAgoElement from './time-ago-element-define.js'
+import TimeUntilElement from './time-until-element-define.js'
 
 export {LocalTimeElement, RelativeTimeElement, TimeAgoElement, TimeUntilElement}

--- a/src/local-time-element-define.ts
+++ b/src/local-time-element-define.ts
@@ -1,0 +1,26 @@
+import LocalTimeElement from './local-time-element.js'
+
+const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
+try {
+  customElements.define('local-time', LocalTimeElement)
+  root.LocalTimeElement = LocalTimeElement
+} catch (e: unknown) {
+  if (
+    !(root.DOMException && e instanceof DOMException && e.name === 'NotSupportedError') &&
+    !(e instanceof ReferenceError)
+  ) {
+    throw e
+  }
+}
+
+declare global {
+  interface Window {
+    LocalTimeElement: typeof LocalTimeElement
+  }
+  interface HTMLElementTagNameMap {
+    'local-time': LocalTimeElement
+  }
+}
+
+export default LocalTimeElement
+export * from './local-time-element.js'

--- a/src/relative-time-element-define.ts
+++ b/src/relative-time-element-define.ts
@@ -1,0 +1,26 @@
+import RelativeTimeElement from './relative-time-element.js'
+
+const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
+try {
+  customElements.define('relative-time', RelativeTimeElement)
+  root.RelativeTimeElement = RelativeTimeElement
+} catch (e: unknown) {
+  if (
+    !(root.DOMException && e instanceof DOMException && e.name === 'NotSupportedError') &&
+    !(e instanceof ReferenceError)
+  ) {
+    throw e
+  }
+}
+
+declare global {
+  interface Window {
+    RelativeTimeElement: typeof RelativeTimeElement
+  }
+  interface HTMLElementTagNameMap {
+    'relative-time': RelativeTimeElement
+  }
+}
+
+export default RelativeTimeElement
+export * from './relative-time-element.js'

--- a/src/time-ago-element-define.ts
+++ b/src/time-ago-element-define.ts
@@ -1,0 +1,26 @@
+import TimeAgoElement from './time-ago-element.js'
+
+const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
+try {
+  customElements.define('time-ago', TimeAgoElement)
+  root.TimeAgoElement = TimeAgoElement
+} catch (e: unknown) {
+  if (
+    !(root.DOMException && e instanceof DOMException && e.name === 'NotSupportedError') &&
+    !(e instanceof ReferenceError)
+  ) {
+    throw e
+  }
+}
+
+declare global {
+  interface Window {
+    TimeAgoElement: typeof TimeAgoElement
+  }
+  interface HTMLElementTagNameMap {
+    'time-ago': TimeAgoElement
+  }
+}
+
+export default TimeAgoElement
+export * from './time-ago-element.js'

--- a/src/time-until-element-define.ts
+++ b/src/time-until-element-define.ts
@@ -1,0 +1,26 @@
+import TimeUntilElement from './time-until-element.js'
+
+const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
+try {
+  customElements.define('time-until', TimeUntilElement)
+  root.TimeUntilElement = TimeUntilElement
+} catch (e: unknown) {
+  if (
+    !(root.DOMException && e instanceof DOMException && e.name === 'NotSupportedError') &&
+    !(e instanceof ReferenceError)
+  ) {
+    throw e
+  }
+}
+
+declare global {
+  interface Window {
+    TimeUntilElement: typeof TimeUntilElement
+  }
+  interface HTMLElementTagNameMap {
+    'time-until': TimeUntilElement
+  }
+}
+
+export default TimeUntilElement
+export * from './time-until-element.js'


### PR DESCRIPTION
Following a discussion with @koddsson - this PR attempts to create a pattern of module definitions within our custom elements.

Effectively, all custom elements can be imported via their bare specifier (so in this case `@github/relative-time-element`). This _will not import the custom element definition_ (though it does here, to avoid breaking changes). Instead one will have to `import '@github/relative-time-element/define'`. This will then import the code which defines the element.

In addition, for this element (at least for now - though these will be removed in a breaking release) the following imports are also enabled:

- `'@github/time-elements` - all classes
- `'@github/time-elements/define` - all classes and their custom element definitions
- `'@github/time-elements/relative-time` - just the relative time element
- `'@github/time-elements/relative-time/define` - just the relative time element and its custom element definition
- `'@github/time-elements/local-time` - just the local time element
- `'@github/time-elements/local-time/define` - just the local time element and its custom element definition
- `'@github/time-elements/time-ago` - just the time-ago element
- `'@github/time-elements/time-ago/define` - just the time-ago element and its custom element definition
- `'@github/time-elements/time-until` - just the time-until element
- `'@github/time-elements/time-until/define` - just the time-until element and its custom element definition

The plan is to remove a lot of these elements in v4, so the following list will be true for v4:

- `'@github/time-elements` - the `relative-time` element
- `'@github/time-elements/define` - the relative time element and its custom element definition