### PR TITLE
fix typo in observed attributes

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -97,7 +97,7 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
       'year',
       'time-zone-name',
       'prefix',
-      'threhsold',
+      'threshold',
       'tense',
       'precision',
       'format',

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -78,6 +78,19 @@ suite('relative-time', function () {
     assert.notEqual(nextDisplay, display)
   })
 
+  test('all observedAttributes have getters', async function () {
+    const ALLOWED_PROPERTIES = ['time-zone-name']
+
+    const members = [
+      ...Object.getOwnPropertyNames(RelativeTimeElement.prototype),
+      ...Object.getOwnPropertyNames(HTMLElement.prototype),
+      ...ALLOWED_PROPERTIES
+    ]
+    const observedAttributes = new Set(RelativeTimeElement.observedAttributes)
+    for (const member of members) observedAttributes.delete(member)
+    assert.empty([...observedAttributes], 'observedAttributes that arent class members')
+  })
+
   test("doesn't error when no date is provided", function () {
     const element = document.createElement('relative-time')
     assert.doesNotThrow(() => element.attributeChangedCallback('datetime', null, null))


### PR DESCRIPTION
There was a typo in the `observedAttributes` set - `threshold` was `threhsold`.

I've also added a test to make sure no typos creep in again.