### PR TITLE
add JSX IntrinsicElement types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,12 @@
   },
   "overrides": [
     {
+      "files": "src/*-define.ts",
+      "rules": {
+        "@typescript-eslint/no-namespace": "off"
+      }
+    },
+    {
       "files": "test/**/*.js",
       "rules": {
         "github/unescaped-html-literal": "off",

--- a/src/local-time-element-define.ts
+++ b/src/local-time-element-define.ts
@@ -20,6 +20,11 @@ declare global {
   interface HTMLElementTagNameMap {
     'local-time': LocalTimeElement
   }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['local-time']: LocalTimeElement
+    }
+  }
 }
 
 export default LocalTimeElement

--- a/src/relative-time-element-define.ts
+++ b/src/relative-time-element-define.ts
@@ -20,6 +20,11 @@ declare global {
   interface HTMLElementTagNameMap {
     'relative-time': RelativeTimeElement
   }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['relative-time']: RelativeTimeElement
+    }
+  }
 }
 
 export default RelativeTimeElement

--- a/src/time-ago-element-define.ts
+++ b/src/time-ago-element-define.ts
@@ -20,6 +20,11 @@ declare global {
   interface HTMLElementTagNameMap {
     'time-ago': TimeAgoElement
   }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['time-ago']: TimeAgoElement
+    }
+  }
 }
 
 export default TimeAgoElement

--- a/src/time-until-element-define.ts
+++ b/src/time-until-element-define.ts
@@ -20,6 +20,11 @@ declare global {
   interface HTMLElementTagNameMap {
     'time-until': TimeUntilElement
   }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['time-until']: TimeUntilElement
+    }
+  }
 }
 
 export default TimeUntilElement


### PR DESCRIPTION
This adds the `JSX.IntrinsicElement` types to the `define` files. Closes #163