### PR TITLE
add JSX IntrinsicElement types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,12 @@
   },
   "overrides": [
     {
+      "files": "src/*-define.ts",
+      "rules": {
+        "@typescript-eslint/no-namespace": "off"
+      }
+    },
+    {
       "files": "test/**/*.js",
       "rules": {
         "github/unescaped-html-literal": "off",

--- a/src/local-time-element-define.ts
+++ b/src/local-time-element-define.ts
@@ -13,12 +13,20 @@ try {
   }
 }
 
+type JSXBaseElement = JSX.IntrinsicElements extends {span: unknown}
+  ? JSX.IntrinsicElements['span']
+  : Record<string, unknown>
 declare global {
   interface Window {
     LocalTimeElement: typeof LocalTimeElement
   }
   interface HTMLElementTagNameMap {
     'local-time': LocalTimeElement
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['local-time']: JSXBaseElement & Partial<Omit<LocalTimeElement, keyof HTMLElement>>
+    }
   }
 }
 

--- a/src/relative-time-element-define.ts
+++ b/src/relative-time-element-define.ts
@@ -13,12 +13,20 @@ try {
   }
 }
 
+type JSXBaseElement = JSX.IntrinsicElements extends {span: unknown}
+  ? JSX.IntrinsicElements['span']
+  : Record<string, unknown>
 declare global {
   interface Window {
     RelativeTimeElement: typeof RelativeTimeElement
   }
   interface HTMLElementTagNameMap {
     'relative-time': RelativeTimeElement
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['relative-time']: JSXBaseElement & Partial<Omit<RelativeTimeElement, keyof HTMLElement>>
+    }
   }
 }
 

--- a/src/time-ago-element-define.ts
+++ b/src/time-ago-element-define.ts
@@ -13,12 +13,20 @@ try {
   }
 }
 
+type JSXBaseElement = JSX.IntrinsicElements extends {span: unknown}
+  ? JSX.IntrinsicElements['span']
+  : Record<string, unknown>
 declare global {
   interface Window {
     TimeAgoElement: typeof TimeAgoElement
   }
   interface HTMLElementTagNameMap {
     'time-ago': TimeAgoElement
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['time-ago']: JSXBaseElement & Partial<Omit<TimeAgoElement, keyof HTMLElement>>
+    }
   }
 }
 

--- a/src/time-until-element-define.ts
+++ b/src/time-until-element-define.ts
@@ -13,12 +13,20 @@ try {
   }
 }
 
+type JSXBaseElement = JSX.IntrinsicElements extends {span: unknown}
+  ? JSX.IntrinsicElements['span']
+  : Record<string, unknown>
 declare global {
   interface Window {
     TimeUntilElement: typeof TimeUntilElement
   }
   interface HTMLElementTagNameMap {
     'time-until': TimeUntilElement
+  }
+  namespace JSX {
+    interface IntrinsicElements {
+      ['time-until']: JSXBaseElement & Partial<Omit<TimeUntilElement, keyof HTMLElement>>
+    }
   }
 }
 


### PR DESCRIPTION
Okay after a bit of a battle I managed to conjur the right typescript incantations which enables us to have operational typescript types, while also not _requiring_ JSX or React types to be installed.

This is a re-opening of https://github.com/github/relative-time-element/pull/213. Something @koddsson asked in hat PR but I didn't answer:

> Are we planning to auto-generate these in the future? I think that could be cool with the Custom Element Manifest if possible. Then it should be trivial to add other bindings for other frameworks as well and we don't have to manually maintain these bindings.

We could definitely take a look at this but in other frameworks this isn't really an issue as they either support custom elements well enough to not require this additional support scaffolding (perhaps by using the `HTMLElementTagNameMap` type) or they use the `JSX.IntrinsicElements` definition anyway. Which is all to say I think we won't need to support any other frameworks. 