### PR TITLE
avoid updating during update call

### DIFF
--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -56,6 +56,19 @@ suite('relative-time', function () {
     assert.equal(counter, 1)
     el.setAttribute('title', 'another custom')
     assert.equal(counter, 1)
+    el.removeAttribute('title')
+    assert.equal(counter, 2)
+  })
+
+  test('sets title back to default if removed', () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date().toISOString())
+    assert.ok(el.getAttribute('title'))
+    const text = el.getAttribute('title')
+    el.setAttribute('title', 'custom')
+    assert.equal(el.getAttribute('title'), 'custom')
+    el.removeAttribute('title')
+    assert.equal(el.getAttribute('title'), text)
   })
 
   test('shadowDOM reflects textContent with invalid date', () => {


### PR DESCRIPTION
We can get into some difficult conditions when frameworks from the outside try to set attributes multiple times because of multiple renders (e.g. react), which can cause the element to stop updating or update over eagerly.

This fix changes the update cycle so that updates to attributes _during_ the `update()` call won't cause `attributeChangedCallback` to update, but meanwhile re-setting `title` to its own contents wont flip the `#customTitle` flag causing updates to stop.