### PR TITLE
add formatStyle attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,27 @@ So, a relative date phrase is used for up to a month and then the actual date is
 
 #### Attributes
 
-| Property Name  | Attribute Name   | Possible Values                                                                             | Default Value          |
-|:---------------|:-----------------|:--------------------------------------------------------------------------------------------|:-----------------------|
-| `datetime`     | `datetime`       | `string`                                                                                    | -                      |
-| `format`       | `format`         | `'auto'\|'micro'\|'elapsed'`                                                                | 'auto'                 |
-| `date`         | -                | `Date \| null`                                                                              | -                      |
-| `tense`        | `tense`          | `'auto'\|'past'\|'future'`                                                                  | `'auto'`               |
-| `precision`    | `precision`      | `'year'\|'month'\|'day'\|'hour'\|'minute'\|'second'`                                        | `'second'`             |
-| `threshold`    | `threshold`      | `string`                                                                                    | `'P30D'`               |
-| `prefix`       | `prefix`         | `string`                                                                                    | `'on'`                 |
-| `second`       | `second`         | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`            |
-| `minute`       | `minute`         | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`            |
-| `hour`         | `hour`           | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`            |
-| `weekday`      | `weekday`        | `'short'\|'long'\|'narrow'\|undefined`                                                      | `undefined`            |
-| `day`          | `day`            | `'numeric'\|'2-digit'\|undefined`                                                           | `'numeric'`            |
-| `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | `'short'`              |
-| `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | `'numeric'`<sup>*</sup>|
-| `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`            |
+| Property Name  | Attribute Name   | Possible Values                                                                             | Default Value                    |
+|:---------------|:-----------------|:--------------------------------------------------------------------------------------------|:---------------------------------|
+| `datetime`     | `datetime`       | `string`                                                                                    | -                                |
+| `format`       | `format`         | `'auto'\|'micro'\|'elapsed'`                                                                | 'auto'                           |
+| `date`         | -                | `Date \| null`                                                                              | -                                |
+| `tense`        | `tense`          | `'auto'\|'past'\|'future'`                                                                  | `'auto'`                         |
+| `precision`    | `precision`      | `'year'\|'month'\|'day'\|'hour'\|'minute'\|'second'`                                        | `'second'`                       |
+| `threshold`    | `threshold`      | `string`                                                                                    | `'P30D'`                         |
+| `prefix`       | `prefix`         | `string`                                                                                    | `'on'`                           |
+| `formatStyle`  | `format-style`   | `'long'\|'short'\|'narrow'`                                                                 | `'long'|'narrow'`<sup>**</sup>   |
+| `second`       | `second`         | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`                      |
+| `minute`       | `minute`         | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`                      |
+| `hour`         | `hour`           | `'numeric'\|'2-digit'\|undefined`                                                           | `undefined`                      |
+| `weekday`      | `weekday`        | `'short'\|'long'\|'narrow'\|undefined`                                                      | `undefined`                      |
+| `day`          | `day`            | `'numeric'\|'2-digit'\|undefined`                                                           | `'numeric'`                      |
+| `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | `'short'`                        |
+| `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | `'numeric'|undefined`<sup>*</sup>|
+| `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
 
 <sup>*</sup>: If unspecified, `year` will return `'numeric'` if `datetime` represents the same year as the current year. It will return `undefined` if unspecified and if `datetime` represents a different year to the current year.
+<sup>**</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'`, or `'long'` otherwise.
 
 ##### datetime (`string`)
 
@@ -186,6 +188,16 @@ When formatting an absolute date (see above `threshold` for more details) it can
   <!-- Will always display "this happened on April 1, 1970" -->
 </relative-time>
 ```
+
+##### formatStyle (`'long'|'short'|'narrow'`, default: `'narrow'|'long'`)
+
+If `'format'` is `auto` then `formatStyle` will be used to determine the length of the unit names. This value is passed to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) as the `style` option. Some examples of how this can be used:
+
+| `format=`  | `formatStyle=` | Display             |
+|:----------:|:--------------:|:-------------------:|
+| auto       | long           | in 1 month          |
+| auto       | short          | in 1 mo.            |
+| auto       | narrow         | in 1 mo.            |
 
 ##### second, minute, hour, weekday, day, month, year, timeZoneName
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -4,6 +4,7 @@ const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof
 const HTMLElement = root.HTMLElement || (null as unknown as typeof window['HTMLElement'])
 
 export type Format = 'auto' | 'micro' | 'elapsed'
+export type FormatStyle = 'long' | 'short' | 'narrow'
 export type Tense = 'auto' | 'past' | 'future'
 
 export class RelativeTimeUpdatedEvent extends Event {
@@ -93,6 +94,7 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
       'tense',
       'precision',
       'format',
+      'formatStyle',
       'datetime',
       'lang',
       'title',
@@ -123,6 +125,7 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
     const date = this.date
     if (!date) return
     const format = this.format
+    const style = this.formatStyle
     if (format === 'elapsed') {
       const precisionIndex = unitNames.indexOf(this.precision) || 0
       const units = elapsedTime(date).filter(unit => unitNames.indexOf(unit[1]) >= precisionIndex)
@@ -134,7 +137,7 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
     const within = withinDuration(now, date, this.threshold)
     const locale = this.#lang
     if (typeof Intl !== 'undefined' && Intl.RelativeTimeFormat) {
-      const relativeFormat = new Intl.RelativeTimeFormat(locale, {numeric: 'auto'})
+      const relativeFormat = new Intl.RelativeTimeFormat(locale, {numeric: 'auto', style})
 
       if (tense === 'past' || (tense === 'auto' && !inFuture && within)) {
         const [int, unit] = micro ? microTimeAgo(date) : timeAgo(date)
@@ -299,6 +302,19 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
 
   set format(value: Format) {
     this.setAttribute('format', value)
+  }
+
+  get formatStyle(): FormatStyle {
+    const formatStyle = this.getAttribute('format-style')
+    if (formatStyle === 'long') return 'long'
+    if (formatStyle === 'short') return 'short'
+    if (formatStyle === 'narrow') return 'narrow'
+    if (this.format === 'elapsed') return 'narrow'
+    return 'long'
+  }
+
+  set formatStyle(value: FormatStyle) {
+    this.setAttribute('format-style', value)
   }
 
   get datetime() {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -813,6 +813,16 @@ suite('relative-time', function () {
       {datetime: '2023-10-24T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
       {datetime: '2024-03-31T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
       {datetime: '2024-04-01T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'in 2 years'},
+      {datetime: '2022-10-24T15:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
+      {datetime: '2022-10-24T16:00:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
+      {datetime: '2022-10-24T16:15:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
+      {datetime: '2022-10-24T16:31:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 2 hr.'},
+      {datetime: '2022-10-30T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 6 days'},
+      {datetime: '2022-11-24T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next mo.'},
+      {datetime: '2023-10-23T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
+      {datetime: '2023-10-24T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
+      {datetime: '2024-03-31T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
+      {datetime: '2024-04-01T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 2 yr.'},
 
       // Dates in the future
       {datetime: '2022-11-24T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'now'},
@@ -830,6 +840,16 @@ suite('relative-time', function () {
       {datetime: '2021-10-24T14:46:00.000Z', tense: 'past', format: 'auto', expected: '12 months ago'},
       {datetime: '2021-05-18T14:46:00.000Z', tense: 'past', format: 'auto', expected: '17 months ago'},
       {datetime: '2021-05-17T14:46:00.000Z', tense: 'past', format: 'auto', expected: '2 years ago'},
+      {datetime: '2022-10-24T13:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
+      {datetime: '2022-10-24T13:30:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
+      {datetime: '2022-10-24T13:17:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
+      {datetime: '2022-10-24T13:01:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '2 hr. ago'},
+      {datetime: '2022-10-18T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '6 days ago'},
+      {datetime: '2022-09-23T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last mo.'},
+      {datetime: '2021-10-25T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '12 mo. ago'},
+      {datetime: '2021-10-24T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '12 mo. ago'},
+      {datetime: '2021-05-18T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '17 mo. ago'},
+      {datetime: '2021-05-17T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '2 yr. ago'},
 
       // Edge case dates
       {
@@ -869,15 +889,28 @@ suite('relative-time', function () {
       },
     ])
 
-    for (const {datetime, expected, tense, format, precision = '', lang = null, reference = referenceDate} of tests) {
-      test(`<relative-time datetime="${datetime}" tense="${tense}" format="${format}"> => ${expected}`, async () => {
+    for (const {
+      datetime,
+      expected,
+      tense,
+      format,
+      formatStyle,
+      precision = '',
+      lang,
+      reference = referenceDate,
+    } of tests) {
+      const attrs = Object.entries({datetime, tense, format, formatStyle, precision}).map(([k, v]) =>
+        v ? `${k}="${v}"` : '',
+      )
+      test(`<relative-time ${attrs.join(' ')}> => ${expected}`, async () => {
         freezeTime(new Date(reference))
         const time = document.createElement('relative-time')
-        time.setAttribute('tense', tense)
         time.setAttribute('datetime', datetime)
-        time.setAttribute('format', format)
-        time.setAttribute('precision', precision)
+        if (tense) time.setAttribute('tense', tense)
+        if (format) time.setAttribute('format', format)
+        if (precision) time.setAttribute('precision', precision)
         if (lang) time.setAttribute('lang', lang)
+        if (formatStyle) time.formatStyle = formatStyle
         await Promise.resolve()
         assert.equal(time.shadowRoot.textContent, expected)
       })


### PR DESCRIPTION
This adds the `formatStyle` attribute. See #220 

Adding this attribute will allow us to separate the formatting style from the format. Right now this just gets applied to `RelativeTimeFormat`, and uses the default option of `long`.
