### PR TITLE
Move elapsed to duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,16 @@ When formatting an absolute date (see above `threshold` for more details) it can
 
 ##### formatStyle (`'long'|'short'|'narrow'`, default: `'narrow'|'long'`)
 
-If `'format'` is `auto` then `formatStyle` will be used to determine the length of the unit names. This value is passed to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) as the `style` option. Some examples of how this can be used:
+If `'format'` is `auto` or `elapsed` then `formatStyle` will be used to determine the length of the unit names. This value is passed to [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) as the `style` option. Some examples of how this can be used:
 
-| `format=`  | `formatStyle=` | Display             |
-|:----------:|:--------------:|:-------------------:|
-| auto       | long           | in 1 month          |
-| auto       | short          | in 1 mo.            |
-| auto       | narrow         | in 1 mo.            |
+| `format=`  | `formatStyle=` | Display                  |
+|:----------:|:--------------:|:------------------------:|
+| auto       | long           | in 1 month               |
+| auto       | short          | in 1 mo.                 |
+| auto       | narrow         | in 1 mo.                 |
+| elapsed    | long           | 1 month, 2 days, 4 hours |
+| auto       | short          | 1 mth, 2 days, 4 hr      |
+| auto       | narrow         | 1m 2d 4h                 |
 
 ##### second, minute, hour, weekday, day, month, year, timeZoneName
 

--- a/src/duration-format-ponyfill.ts
+++ b/src/duration-format-ponyfill.ts
@@ -1,0 +1,126 @@
+import {Duration} from './duration.js'
+
+class ListFormatPonyFill {
+  formatToParts(members: Iterable<string>) {
+    const parts: DurationPart[] = []
+    for (const value of members) {
+      parts.push({type: 'element', value})
+      parts.push({type: 'literal', value: ', '})
+    }
+    return parts.slice(0, -1)
+  }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ListFormat = (typeof Intl !== 'undefined' && (Intl as any).ListFormat) || ListFormatPonyFill
+
+interface DurationFormatResolvedOptions {
+  locale: string
+  style: 'long' | 'short' | 'narrow' | 'digital'
+  years: 'long' | 'short' | 'narrow'
+  yearsDisplay: 'always' | 'auto'
+  months: 'long' | 'short' | 'narrow'
+  monthsDisplay: 'always' | 'auto'
+  weeks: 'long' | 'short' | 'narrow'
+  weeksDisplay: 'always' | 'auto'
+  days: 'long' | 'short' | 'narrow'
+  daysDisplay: 'always' | 'auto'
+  hours: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit'
+  hoursDisplay: 'always' | 'auto'
+  minutes: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit'
+  minutesDisplay: 'always' | 'auto'
+  seconds: 'long' | 'short' | 'narrow' | 'numeric' | '2-digit'
+  secondsDisplay: 'always' | 'auto'
+  milliseconds: 'long' | 'short' | 'narrow' | 'numeric'
+  millisecondsDisplay: 'always' | 'auto'
+}
+
+export type DurationFormatOptions = Partial<Omit<DurationFormatResolvedOptions, 'locale'>>
+
+const partsTable = [
+  ['years', 'year'],
+  ['months', 'month'],
+  ['weeks', 'week'],
+  ['days', 'day'],
+  ['hours', 'hour'],
+  ['minutes', 'minute'],
+  ['seconds', 'second'],
+  ['milliseconds', 'millisecond'],
+] as const
+
+interface DurationPart {
+  type: 'integer' | 'literal' | 'element'
+  value: string
+}
+
+const twoDigitFormatOptions = {minimumIntegerDigits: 2}
+
+export default class DurationFormat {
+  #options: DurationFormatResolvedOptions
+
+  constructor(locale: string, options: DurationFormatOptions = {}) {
+    let style = String(options.style || 'short') as DurationFormatResolvedOptions['style']
+    if (style !== 'long' && style !== 'short' && style !== 'narrow' && style !== 'digital') style = 'short'
+    let prevStyle: DurationFormatResolvedOptions['hours'] = style === 'digital' ? 'numeric' : style
+    const hours = options.hours || prevStyle
+    prevStyle = hours === '2-digit' ? 'numeric' : hours
+    const minutes = options.minutes || prevStyle
+    prevStyle = minutes === '2-digit' ? 'numeric' : minutes
+    const seconds = options.seconds || prevStyle
+    prevStyle = seconds === '2-digit' ? 'numeric' : seconds
+    const milliseconds = options.milliseconds || prevStyle
+    this.#options = {
+      locale,
+      style,
+      years: options.years || style === 'digital' ? 'short' : style,
+      yearsDisplay: options.yearsDisplay === 'always' ? 'always' : 'auto',
+      months: options.months || style === 'digital' ? 'short' : style,
+      monthsDisplay: options.monthsDisplay === 'always' ? 'always' : 'auto',
+      weeks: options.weeks || style === 'digital' ? 'short' : style,
+      weeksDisplay: options.weeksDisplay === 'always' ? 'always' : 'auto',
+      days: options.days || style === 'digital' ? 'short' : style,
+      daysDisplay: options.daysDisplay === 'always' ? 'always' : 'auto',
+      hours,
+      hoursDisplay: options.hoursDisplay === 'always' ? 'always' : style === 'digital' ? 'always' : 'auto',
+      minutes,
+      minutesDisplay: options.minutesDisplay === 'always' ? 'always' : style === 'digital' ? 'always' : 'auto',
+      seconds,
+      secondsDisplay: options.secondsDisplay === 'always' ? 'always' : style === 'digital' ? 'always' : 'auto',
+      milliseconds,
+      millisecondsDisplay: options.millisecondsDisplay === 'always' ? 'always' : 'auto',
+    }
+  }
+
+  resolvedOptions() {
+    return this.#options
+  }
+
+  formatToParts(opts: unknown): DurationPart[] {
+    const list: string[] = []
+    const options = this.#options
+    const style = options.style
+    const locale = options.locale
+    const duration = Duration.from(opts)
+    for (const [unit, nfUnit] of partsTable) {
+      const value = duration[unit]
+      if (options[`${unit}Display`] === 'auto' && !value) continue
+      const unitStyle = options[unit]
+      const nfOpts =
+        unitStyle === '2-digit'
+          ? twoDigitFormatOptions
+          : unitStyle === 'numeric'
+          ? {}
+          : {style: 'unit', unit: nfUnit, unitDisplay: unitStyle}
+      list.push(new Intl.NumberFormat(locale, nfOpts).format(value))
+    }
+    return new ListFormat(locale, {
+      type: 'unit',
+      style: style === 'digital' ? 'short' : style,
+    }).formatToParts(list)
+  }
+
+  format(opts: unknown) {
+    return this.formatToParts(opts)
+      .map(p => p.value)
+      .join('')
+  }
+}

--- a/src/duration-format.ts
+++ b/src/duration-format.ts
@@ -1,7 +1,4 @@
-export const unitNames = ['second', 'minute', 'hour', 'day', 'month', 'year'] as const
-export type Unit = typeof unitNames[number]
-
-export function timeAgo(date: Date): [number, Unit] {
+export function timeAgo(date: Date): [number, Intl.RelativeTimeFormatUnit] {
   const ms = new Date().getTime() - date.getTime()
   const sec = Math.round(ms / 1000)
   const min = Math.round(sec / 60)
@@ -34,7 +31,7 @@ export function timeAgo(date: Date): [number, Unit] {
   }
 }
 
-export function microTimeAgo(date: Date): [number, Unit] {
+export function microTimeAgo(date: Date): [number, Intl.RelativeTimeFormatUnit] {
   const ms = new Date().getTime() - date.getTime()
   const sec = Math.round(ms / 1000)
   const min = Math.round(sec / 60)
@@ -55,7 +52,7 @@ export function microTimeAgo(date: Date): [number, Unit] {
   }
 }
 
-export function timeUntil(date: Date): [number, Unit] {
+export function timeUntil(date: Date): [number, Intl.RelativeTimeFormatUnit] {
   const ms = date.getTime() - new Date().getTime()
   const sec = Math.round(ms / 1000)
   const min = Math.round(sec / 60)
@@ -90,7 +87,7 @@ export function timeUntil(date: Date): [number, Unit] {
   }
 }
 
-export function microTimeUntil(date: Date): [number, Unit] {
+export function microTimeUntil(date: Date): [number, Intl.RelativeTimeFormatUnit] {
   const ms = date.getTime() - new Date().getTime()
   const sec = Math.round(ms / 1000)
   const min = Math.round(sec / 60)
@@ -109,22 +106,4 @@ export function microTimeUntil(date: Date): [number, Unit] {
   } else {
     return [1, 'minute']
   }
-}
-
-export function elapsedTime(date: Date): Array<[number, Unit]> {
-  const ms = Math.abs(date.getTime() - new Date().getTime())
-  const sec = Math.floor(ms / 1000)
-  const min = Math.floor(sec / 60)
-  const hr = Math.floor(min / 60)
-  const day = Math.floor(hr / 24)
-  const month = Math.floor(day / 30)
-  const year = Math.floor(month / 12)
-  const units: Array<[number, Unit]> = []
-  if (year) units.push([year, 'year'])
-  if (month - year * 12) units.push([month - year * 12, 'month'])
-  if (day - month * 30) units.push([day - month * 30, 'day'])
-  if (hr - day * 24) units.push([hr - day * 24, 'hour'])
-  if (min - hr * 60) units.push([min - hr * 60, 'minute'])
-  if (sec - min * 60) units.push([sec - min * 60, 'second'])
-  return units
 }

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,4 +1,6 @@
 const durationRe = /^[-+]?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+export const unitNames = ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond'] as const
+export type Unit = typeof unitNames[number]
 
 export const isDuration = (str: string) => durationRe.test(str)
 
@@ -61,4 +63,25 @@ export function withinDuration(a: Date | number, b: Date | number, str: string):
   const threshold = applyDuration(a, duration)
   if (!threshold) return true
   return Math.abs(Number(threshold) - Number(a)) > Math.abs(Number(a) - Number(b))
+}
+
+export function elapsedTime(date: Date, precision: Unit = 'second', now = Date.now()): Duration {
+  const ms = Math.abs(date.getTime() - now)
+  const sec = Math.floor(ms / 1000)
+  const min = Math.floor(sec / 60)
+  const hr = Math.floor(min / 60)
+  const day = Math.floor(hr / 24)
+  const month = Math.floor(day / 30)
+  const year = Math.floor(month / 12)
+  const i = unitNames.indexOf(precision) || unitNames.length
+  return new Duration(
+    i >= 0 ? year : 0,
+    i >= 1 ? month - year * 12 : 0,
+    0,
+    i >= 2 ? day - month * 30 : 0,
+    i >= 3 ? hr - day * 24 : 0,
+    i >= 4 ? min - hr * 60 : 0,
+    i >= 5 ? sec - min * 60 : 0,
+    i >= 6 ? ms - sec * 1000 : 0
+  )
 }

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -82,6 +82,6 @@ export function elapsedTime(date: Date, precision: Unit = 'second', now = Date.n
     i >= 3 ? hr - day * 24 : 0,
     i >= 4 ? min - hr * 60 : 0,
     i >= 5 ? sec - min * 60 : 0,
-    i >= 6 ? ms - sec * 1000 : 0
+    i >= 6 ? ms - sec * 1000 : 0,
   )
 }

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -1,5 +1,6 @@
-import {unitNames, Unit, microTimeAgo, microTimeUntil, timeUntil, timeAgo, elapsedTime} from './duration-format.js'
-import {isDuration, withinDuration} from './duration.js'
+import {microTimeAgo, microTimeUntil, timeUntil, timeAgo} from './duration-format.js'
+import {unitNames, Unit, isDuration, withinDuration, elapsedTime} from './duration.js'
+import DurationFormat from './duration-format-ponyfill.js'
 const root = (typeof globalThis !== 'undefined' ? globalThis : window) as typeof window
 const HTMLElement = root.HTMLElement || (null as unknown as typeof window['HTMLElement'])
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -125,18 +125,17 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
   #getFormattedDate(now = Date.now()): string | undefined {
     const date = this.date
     if (!date) return
+    const locale = this.#lang
     const format = this.format
     const style = this.formatStyle
     if (format === 'elapsed') {
-      const precisionIndex = unitNames.indexOf(this.precision) || 0
-      const units = elapsedTime(date).filter(unit => unitNames.indexOf(unit[1]) >= precisionIndex)
-      return units.map(([int, unit]) => `${int}${unit[0]}`).join(' ') || `0${this.precision[0]}`
+      const durationFormat = new DurationFormat(locale, {style}).format(elapsedTime(date, this.precision, now))
+      return durationFormat || new DurationFormat(locale, {style, minutesDisplay: 'always'}).format('PT0M')
     }
     const tense = this.tense
     const micro = format === 'micro'
     const inFuture = now < date.getTime()
     const within = withinDuration(now, date, this.threshold)
-    const locale = this.#lang
     if (typeof Intl !== 'undefined' && Intl.RelativeTimeFormat) {
       const relativeFormat = new Intl.RelativeTimeFormat(locale, {numeric: 'auto', style})
 

--- a/test/duration-format-ponyfill.ts
+++ b/test/duration-format-ponyfill.ts
@@ -1,0 +1,106 @@
+import {assert} from '@open-wc/testing'
+
+import DurationFormat from '../src/duration-format-ponyfill.js'
+import type {DurationFormatOptions} from '../src/duration-format-ponyfill.js'
+
+suite('duration format ponyfill', function () {
+  const tests = new Set([
+    {duration: 'PT8S', locale: 'en', parts: [{type: 'element', value: '8 sec'}]},
+    {duration: 'PT8S', locale: 'en', style: 'long', parts: [{type: 'element', value: '8 seconds'}]},
+    {
+      duration: 'P1M2DT4H',
+      locale: 'en',
+      style: 'long',
+      parts: [
+        {type: 'element', value: '1 month'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '2 days'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '4 hours'},
+      ],
+    },
+    {
+      duration: 'P1M2DT4H',
+      locale: 'en',
+      style: 'short',
+      parts: [
+        {type: 'element', value: '1 mth'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '2 days'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '4 hr'},
+      ],
+    },
+    {
+      duration: 'P1M2DT4H',
+      locale: 'en',
+      style: 'narrow',
+      parts: [
+        {type: 'element', value: '1m'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '2d'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '4h'},
+      ],
+    },
+    {
+      duration: 'P4DT6H8S',
+      locale: 'en',
+      style: 'long',
+      parts: [
+        {type: 'element', value: '4 days'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '6 hours'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '8 seconds'},
+      ],
+    },
+    {
+      duration: 'P4DT6H8S',
+      locale: 'fr',
+      style: 'long',
+      parts: [
+        {type: 'element', value: '4 jours'},
+        {type: 'literal', value: ', '},
+        {type: 'element', value: '6 heures'},
+        {type: 'literal', value: ' et '},
+        {type: 'element', value: '8 secondes'},
+      ],
+    },
+    {
+      duration: 'P4DT6H8S',
+      locale: 'en',
+      style: 'narrow',
+      parts: [
+        {type: 'element', value: '4d'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '6h'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '8s'},
+      ],
+    },
+    {
+      duration: 'P4DT6H8S',
+      locale: 'fr',
+      style: 'narrow',
+      parts: [
+        {type: 'element', value: '4j'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '6h'},
+        {type: 'literal', value: ' '},
+        {type: 'element', value: '8s'},
+      ],
+    },
+  ])
+
+  for (const {duration, locale, parts, ...opts} of tests) {
+    test(`DurationFormat(${locale}, ${JSON.stringify(opts)}).formatToParts(${JSON.stringify(
+      duration,
+    )}) === ${JSON.stringify(parts)}`, function () {
+      assert.deepEqual(
+        new DurationFormat(locale, opts as unknown as DurationFormatOptions).formatToParts(duration),
+        parts,
+      )
+    })
+  }
+})

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -1,5 +1,5 @@
 import {assert} from '@open-wc/testing'
-import {Duration, applyDuration, withinDuration} from '../src/duration.ts'
+import {Duration, applyDuration, withinDuration, elapsedTime} from '../src/duration.ts'
 import {Temporal} from '@js-temporal/polyfill'
 
 suite('duration', function () {
@@ -75,6 +75,38 @@ suite('duration', function () {
       test(`${inputA} not within ${duration} of ${inputB}`, () => {
         assert.notOk(withinDuration(new Date(inputA), new Date(inputB), duration))
         assert.notOk(withinDuration(new Date(inputB), new Date(inputA), duration))
+      })
+    }
+  })
+
+  suite('elapsedTime', function () {
+    const elapsed = new Set([
+      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'P9M3D'},
+      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:45.104Z', expected: 'P9M3DT1S'},
+      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:45.104Z', precision: 'day', expected: 'P9M3D'},
+      {now: '2022-10-21T16:44:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'PT4M'},
+      {now: '2022-09-22T16:48:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'P29D'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:46:10.000Z', expected: 'PT10S'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:45:50.000Z', expected: 'PT10S'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:45:50.000Z', precision: 'minute', expected: 'PT0M'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:47:40.000Z', expected: 'PT1M40S'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:44:20.000Z', expected: 'PT1M40S'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:44:20.000Z', precision: 'minute', expected: 'PT1M'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:51:40.000Z', expected: 'PT1H5M40S'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:51:40.000Z', precision: 'minute', expected: 'PT1H5M'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:52:00.000Z', expected: 'PT1H6M'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T17:46:00.000Z', expected: 'PT3H'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T10:46:00.000Z', expected: 'PT4H'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-25T18:46:00.000Z', expected: 'P1DT4H'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-23T10:46:00.000Z', expected: 'P1DT4H'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-23T10:46:00.000Z', precision: 'day', expected: 'P1D'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-30T14:46:00.000Z', expected: 'P11M29D'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-30T14:46:00.000Z', precision: 'month', expected: 'P11M'},
+      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-29T14:46:00.000Z', expected: 'P1Y'},
+    ])
+    for (const {input, now, precision = 'millisecond', expected} of elapsed) {
+      test(`${input} is ${expected} elapsed from ${now} (precision ${precision})`, () => {
+        assert.deepEqual(elapsedTime(new Date(input), precision, new Date(now).getTime()), Duration.from(expected))
       })
     }
   })


### PR DESCRIPTION
This PR adds a ponyfill for the new [`Intl.DurationFormat`](https://tc39.es/proposal-intl-duration-format/) constructor, which can be used to take a `Duration` object (the spec asks for a Temporal Duration object, but our `Duration` object is similar enough to work), and convert it into a localised list of names, e.g `P1Y2D` becomes `1 year, 2 days`. This also has a `narrow` format which would display as `1y 2d`. 

The ponyfill uses [`Intl.NumberFormat`](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_format) which has been supported in browsers as far back as IE11. It also uses [`Intl.ListFormat`](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_format) with a fallback to a class which effectively does `.join(', ')`. This is mostly because this is not as well supported in Safari/macos.