### PR TITLE
Add a job to publish the package in GPR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [bump-version, create-release]
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Checkout ref

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish-npm:
+    name: Publish to npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,3 +44,26 @@ jobs:
       - run: npm whoami; npm --ignore-scripts publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  publish-github:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    needs: [bump-version, create-release]
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout ref
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - name: Install npm depencies
+        run: npm ci
+      - name: Build package
+        run: npm run build
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a job to publish the `relative-time-element` package to GPR (GitHub Private Registry) because having the package only on NPM under `@github` scope causes an issue for some repos (memex, dotcom) whose automation dependency management are configured to install these private packages from GRP in the @github scope not NPM @github  scope.

For more info, see [this slack thread](https://github.slack.com/archives/CMZ4DC9BL/p1670852971245929)