### PR TITLE
Actions: Remove `needs`  from the publish-github job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,6 @@ jobs:
   publish-github:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: [bump-version, create-release]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
`Publish` action is [failed](https://github.com/github/relative-time-element/actions/runs/3689762049) due to unknown `create-release` action. This PR removes this because we manage the releases manually in this repo and we don't need `needs`. Please let me know if I miss anything or misinterpreted the error message!