### PR TITLE
avoid throwing errors for empty lang attributes

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -78,7 +78,11 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
   #updating: false | Promise<void> = false
 
   get #lang() {
-    return this.closest('[lang]')?.getAttribute('lang') ?? 'default'
+    return (
+      this.closest('[lang]')?.getAttribute('lang') ||
+      this.ownerDocument.documentElement.getAttribute('lang') ||
+      'default'
+    )
   }
 
   #renderRoot: Node = this.shadowRoot ? this.shadowRoot : this.attachShadow ? this.attachShadow({mode: 'open'}) : this

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -27,6 +27,7 @@ suite('relative-time', function () {
   suiteSetup(() => {
     fixture = document.createElement('div')
     document.body.appendChild(fixture)
+    document.documentElement.lang = 'en'
   })
 
   teardown(() => {
@@ -247,6 +248,24 @@ suite('relative-time', function () {
     time.setAttribute('datetime', now)
     await Promise.resolve()
     assert.equal(time.shadowRoot.textContent, 'in 2 days')
+  })
+
+  test('uses html lang if given lang is invalid', async () => {
+    const time = document.createElement('relative-time')
+    time.setAttribute('datetime', new Date())
+    time.setAttribute('lang', '')
+    document.documentElement.lang = 'es'
+    await Promise.resolve()
+    assert.equal(time.shadowRoot.textContent, 'ahora')
+  })
+
+  test('ignores empty lang attributes', async () => {
+    const time = document.createElement('relative-time')
+    time.setAttribute('datetime', new Date())
+    time.setAttribute('lang', '')
+    document.documentElement.lang = ''
+    await Promise.resolve()
+    assert.equal(time.shadowRoot.textContent, 'now')
   })
 
   suite('[threshold]', function () {


### PR DESCRIPTION
When the elements `lang` attribute is set to an empty string (`''`) this can cause the element to fail because `''` is not a valid language tag.

This changes the element to use logical or (`||`) to ensure that falsy string values are ignored. In addition, to avoid `lang=''` being treated as `'default'`, it will attempt to revert to the document's `lang` if it cannot find a reasonable `lang` attribute to use up the tree. This way if `<html lang="...">` is valid, it will use that.