### PR TITLE
Year setter typo

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -258,7 +258,7 @@ export default class RelativeTimeElement extends HTMLElement implements Intl.Dat
   }
 
   set year(value: 'numeric' | '2-digit' | undefined) {
-    this.setAttribute('day', value || '')
+    this.setAttribute('year', value || '')
   }
 
   get timeZoneName() {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -384,7 +384,7 @@ suite('relative-time', function () {
     time.setAttribute('lang', 'en-US')
     time.setAttribute('format', '')
     await Promise.resolve()
-    assert.equal(time.shadowRoot.textContent, 'on Jan 10')
+    assert.equal(time.shadowRoot.textContent, 'on Jan 10, 2022')
   })
 
   const esLangSupport = (function () {


### PR DESCRIPTION
I've noticed that there's a typo in the year setter, preventing the ability to customize the format for the year (especially when using the `datetime` format) - it affects the day format instead. 

One test (unrelated) also expected its output to omit the date because of the default behavior when the current year is the same as the date's year, so the second commit here addresses that failing test.