### PR TITLE
update rounding rules for months/years in Duration

### DIFF
--- a/test/duration.ts
+++ b/test/duration.ts
@@ -1,5 +1,5 @@
 import {assert} from '@open-wc/testing'
-import {Duration, applyDuration, elapsedTime, roundToSingleUnit, getRelativeTimeUnit} from '../src/duration.ts'
+import {applyDuration, Duration, elapsedTime, getRelativeTimeUnit, roundToSingleUnit} from '../src/duration.ts'
 import {Temporal} from '@js-temporal/polyfill'
 
 suite('duration', function () {
@@ -8,7 +8,15 @@ suite('duration', function () {
       {input: 'P4Y', years: 4},
       {input: '-P4Y', years: -4},
       {input: '-P3MT5M', months: -3, minutes: -5},
-      {input: 'P1Y2M3DT4H5M6S', years: 1, months: 2, days: 3, hours: 4, minutes: 5, seconds: 6},
+      {
+        input: 'P1Y2M3DT4H5M6S',
+        years: 1,
+        months: 2,
+        days: 3,
+        hours: 4,
+        minutes: 5,
+        seconds: 6,
+      },
       {input: 'P5W', weeks: 5},
       {input: '-P5W', weeks: -5},
     ])
@@ -91,28 +99,122 @@ suite('duration', function () {
 
   suite('elapsedTime', function () {
     const elapsed = new Set([
-      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'P9M3D'},
-      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:45.104Z', expected: 'P9M3DT1S'},
-      {now: '2022-01-21T16:48:44.104Z', input: '2022-10-21T16:48:45.104Z', precision: 'day', expected: 'P9M3D'},
-      {now: '2022-10-21T16:44:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'PT4M'},
-      {now: '2022-09-22T16:48:44.104Z', input: '2022-10-21T16:48:44.104Z', expected: 'P29D'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:46:10.000Z', expected: 'PT10S'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:45:50.000Z', expected: '-PT10S'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:45:50.000Z', precision: 'minute', expected: 'PT0M'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:47:40.000Z', expected: 'PT1M40S'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:44:20.000Z', expected: '-PT1M40S'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T14:44:20.000Z', precision: 'minute', expected: '-PT1M'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:51:40.000Z', expected: 'PT1H5M40S'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:51:40.000Z', precision: 'minute', expected: 'PT1H5M'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T15:52:00.000Z', expected: 'PT1H6M'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T17:46:00.000Z', expected: 'PT3H'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-24T10:46:00.000Z', expected: '-PT4H'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-25T18:46:00.000Z', expected: 'P1DT4H'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-23T10:46:00.000Z', expected: '-P1DT4H'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2022-10-23T10:46:00.000Z', precision: 'day', expected: '-P1D'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-30T14:46:00.000Z', expected: '-P11M29D'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-30T14:46:00.000Z', precision: 'month', expected: '-P11M'},
-      {now: '2022-10-24T14:46:00.000Z', input: '2021-10-29T14:46:00.000Z', expected: '-P1Y'},
+      {
+        now: '2022-01-21T16:48:44.104Z',
+        input: '2022-10-21T16:48:44.104Z',
+        expected: 'P9M3D',
+      },
+      {
+        now: '2022-01-21T16:48:44.104Z',
+        input: '2022-10-21T16:48:45.104Z',
+        expected: 'P9M3DT1S',
+      },
+      {
+        now: '2022-01-21T16:48:44.104Z',
+        input: '2022-10-21T16:48:45.104Z',
+        precision: 'day',
+        expected: 'P9M3D',
+      },
+      {
+        now: '2022-10-21T16:44:44.104Z',
+        input: '2022-10-21T16:48:44.104Z',
+        expected: 'PT4M',
+      },
+      {
+        now: '2022-09-22T16:48:44.104Z',
+        input: '2022-10-21T16:48:44.104Z',
+        expected: 'P29D',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:46:10.000Z',
+        expected: 'PT10S',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:45:50.000Z',
+        expected: '-PT10S',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:45:50.000Z',
+        precision: 'minute',
+        expected: 'PT0M',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:47:40.000Z',
+        expected: 'PT1M40S',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:44:20.000Z',
+        expected: '-PT1M40S',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T14:44:20.000Z',
+        precision: 'minute',
+        expected: '-PT1M',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T15:51:40.000Z',
+        expected: 'PT1H5M40S',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T15:51:40.000Z',
+        precision: 'minute',
+        expected: 'PT1H5M',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T15:52:00.000Z',
+        expected: 'PT1H6M',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T17:46:00.000Z',
+        expected: 'PT3H',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-24T10:46:00.000Z',
+        expected: '-PT4H',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-25T18:46:00.000Z',
+        expected: 'P1DT4H',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-23T10:46:00.000Z',
+        expected: '-P1DT4H',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2022-10-23T10:46:00.000Z',
+        precision: 'day',
+        expected: '-P1D',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2021-10-30T14:46:00.000Z',
+        expected: '-P11M29D',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2021-10-30T14:46:00.000Z',
+        precision: 'month',
+        expected: '-P11M',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2021-10-29T14:46:00.000Z',
+        expected: '-P1Y',
+      },
     ])
     for (const {input, now, precision = 'millisecond', expected} of elapsed) {
       test(`${input} is ${expected} elapsed from ${now} (precision ${precision})`, () => {
@@ -142,24 +244,46 @@ suite('duration', function () {
       ['P24D', 'P3W'],
       ['P24DT25H', 'P1M'],
       ['P25D', 'P1M'],
-      ['P8M', 'P8M'],
-      ['P9M', 'P9M'],
       ['P1M1D', 'P1M'],
-      ['P9M20DT25H', 'P9M'],
-      ['P9M24DT25H', 'P10M'],
-      ['P11M', 'P1Y'],
-      ['P1Y4D', 'P1Y'],
-      ['P1Y5M13D', 'P1Y'],
-      ['P1Y5M15D', 'P1Y'],
-      ['P1Y5M20D', 'P1Y'],
-      ['P1Y11M', 'P2Y'],
+      ['-P1D', '-P1D', {relativeTo: new Date('2022-01-01T00:00:00Z')}],
+      ['P8M', 'P8M', {relativeTo: new Date('2022-01-01T00:00:00Z')}],
+      ['-P8M', '-P8M', {relativeTo: new Date('2022-10-01T00:00:00Z')}],
+      ['P9M', 'P9M', {relativeTo: new Date('2022-01-01T00:00:00Z')}],
+      ['-P9M', '-P9M', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['-P1M', '-P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
+      ['P1M', 'P1Y', {relativeTo: new Date('2023-12-01T00:00:00Z')}],
+      ['-P18M', '-P2Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
+      ['P18M', 'P2Y', {relativeTo: new Date('2023-12-01T00:00:00Z')}],
+      ['-P18M', '-P2Y', {relativeTo: new Date('2023-07-01T00:00:00Z')}],
+      ['P18M', 'P2Y', {relativeTo: new Date('2023-07-01T00:00:00Z')}],
+      ['-P18M', '-P1Y', {relativeTo: new Date('2023-08-01T00:00:00Z')}],
+      ['P18M', 'P1Y', {relativeTo: new Date('2023-03-01T00:00:00Z')}],
+      ['-P9M20DT25H', '-P9M', {relativeTo: new Date('2023-11-12T00:00:00Z')}],
+      ['P9M20DT25H', 'P9M', {relativeTo: new Date('2023-01-12T00:00:00Z')}],
+      ['P11M', 'P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['-P11M', '-P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['P1Y4D', 'P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['P1Y5M13D', 'P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
+      ['P1Y5M15D', 'P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
+      ['P1Y5M20D', 'P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
+      ['P1Y10M', 'P2Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['-P1Y10M', '-P2Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['P1Y10M', 'P1Y', {relativeTo: new Date('2022-01-01T00:00:00Z')}],
+      ['-P1Y10M', '-P1Y', {relativeTo: new Date('2022-12-01T00:00:00Z')}],
     ])
-    for (const [input, expected] of roundTests) {
+    for (const [input, expected, opts] of roundTests) {
       test(`roundToSingleUnit(${input}) === ${expected}`, () => {
-        assert.deepEqual(roundToSingleUnit(Duration.from(input)), Duration.from(expected))
+        assert.deepEqual(
+          roundToSingleUnit(Duration.from(input), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
+          Duration.from(expected),
+        )
       })
+      if (opts?.relativeTo) continue
       test(`roundToSingleUnit(-${input}) === -${expected}`, () => {
-        assert.deepEqual(roundToSingleUnit(Duration.from(`-${input}`)), Duration.from(`-${expected}`))
+        assert.deepEqual(
+          roundToSingleUnit(Duration.from(`-${input}`), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
+          Duration.from(`-${expected}`),
+        )
       })
     }
   })
@@ -185,24 +309,129 @@ suite('duration', function () {
       ['P24D', [3, 'week']],
       ['P24DT25H', [1, 'month']],
       ['P25D', [1, 'month']],
-      ['P8M', [8, 'month']],
-      ['P9M', [9, 'month']],
+      [
+        'P8M',
+        [8, 'month'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P8M',
+        [-8, 'month'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
+      [
+        'P9M',
+        [9, 'month'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P9M',
+        [-9, 'month'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
       ['P1M1D', [1, 'month']],
-      ['P9M20DT25H', [9, 'month']],
-      ['P9M24DT25H', [10, 'month']],
+      [
+        'P9M20DT25H',
+        [9, 'month'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P9M20DT25H',
+        [-9, 'month'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
+      [
+        'P9M24DT25H',
+        [10, 'month'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P9M24DT25H',
+        [-10, 'month'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
       ['P11M', [1, 'year']],
       ['P1Y4D', [1, 'year']],
-      ['P1Y5M13D', [1, 'year']],
-      ['P1Y5M15D', [1, 'year']],
-      ['P1Y5M20D', [1, 'year']],
-      ['P1Y11M', [2, 'year']],
+      [
+        'P1Y5M13D',
+        [1, 'year'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P1Y5M13D',
+        [-1, 'year'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
+      [
+        'P1Y5M15D',
+        [1, 'year'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P1Y5M15D',
+        [-1, 'year'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
+      [
+        'P1Y5M20D',
+        [2, 'year'],
+        {
+          relativeTo: new Date('2022-12-01T00:00:00Z'),
+        },
+      ],
+      [
+        '-P1Y5M20D',
+        [-2, 'year'],
+        {
+          relativeTo: new Date('2022-01-01T00:00:00Z'),
+        },
+      ],
+      ['P1Y10M', [2, 'year'], {relativeTo: new Date('2022-12-01T00:00:00Z')}],
+      [
+        '-P1Y10M',
+        [-2, 'year'],
+        {
+          relativeTo: new Date('2022-10-01T00:00:00Z'),
+        },
+      ],
     ])
-    for (const [input, [val, unit]] of relativeTests) {
-      test(`roundToSingleUnit(${input}) === [${val}, ${unit}]`, () => {
-        assert.deepEqual(getRelativeTimeUnit(Duration.from(input)), [val, unit])
+    for (const [input, [val, unit], opts] of relativeTests) {
+      test(`getRelativeTimeUnit(${input}) === [${val}, ${unit}]`, () => {
+        assert.deepEqual(
+          getRelativeTimeUnit(Duration.from(input), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
+          [val, unit],
+        )
       })
-      test(`roundToSingleUnit(-${input}) === [-${val}, ${unit}]`, () => {
-        assert.deepEqual(getRelativeTimeUnit(Duration.from(`-${input}`)), [-val, unit])
+      if (opts?.relativeTo) continue
+      test(`getRelativeTimeUnit(-${input}) === [-${val}, ${unit}]`, () => {
+        assert.deepEqual(
+          getRelativeTimeUnit(Duration.from(`-${input}`), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
+          [-val, unit],
+        )
       })
     }
   })

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -279,10 +279,10 @@ suite('relative-time', function () {
     })
 
     test('switches to dates after 30 future days with default threshold', async () => {
-      const now = new Date(Date.now() + 31 * 60 * 60 * 24 * 1000).toISOString()
+      freezeTime(new Date('2023-01-01T00:00:00Z'))
       const time = document.createElement('relative-time')
       time.setAttribute('lang', 'en-US')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-02-10T00:00:00Z')
       await Promise.resolve()
       assert.match(time.shadowRoot.textContent, /on [A-Z][a-z]{2} \d{1,2}/)
     })
@@ -298,40 +298,40 @@ suite('relative-time', function () {
     })
 
     test('switches to dates after 30 future days with default threshold', async () => {
-      const now = new Date(Date.now() + 31 * 60 * 60 * 24 * 1000).toISOString()
+      freezeTime(new Date('2023-01-01T00:00:00Z'))
       const time = document.createElement('relative-time')
       time.setAttribute('lang', 'en-US')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-02-10T00:00:00Z')
       await Promise.resolve()
       assert.match(time.shadowRoot.textContent, /on [A-Z][a-z]{2} \d{1,2}/)
     })
 
     test('switches to dates after 30 future days with P1D threshold', async () => {
-      const now = new Date(Date.now() + 2 * 60 * 60 * 24 * 1000).toISOString()
+      freezeTime(new Date('2023-01-01T00:00:00Z'))
       const time = document.createElement('relative-time')
       time.setAttribute('lang', 'en-US')
       time.setAttribute('threshold', 'P1D')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-01-03T00:00:00Z')
       await Promise.resolve()
       assert.match(time.shadowRoot.textContent, /on [A-Z][a-z]{2} \d{1,2}/)
     })
 
     test('uses `prefix` attribute to customise prefix', async () => {
-      const now = new Date(Date.now() + 31 * 60 * 60 * 24 * 1000).toISOString()
+      freezeTime(new Date('2023-01-01T00:00:00Z'))
       const time = document.createElement('relative-time')
       time.setAttribute('prefix', 'will happen by')
       time.setAttribute('lang', 'en-US')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-02-01T00:00:00.000Z')
       await Promise.resolve()
       assert.match(time.shadowRoot.textContent, /will happen by [A-Z][a-z]{2} \d{1,2}/)
     })
 
     test('uses `prefix` attribute to customise prefix as empty string', async () => {
-      const now = new Date(Date.now() + 31 * 60 * 60 * 24 * 1000).toISOString()
+      freezeTime(new Date('2023-01-01T00:00:00Z'))
       const time = document.createElement('relative-time')
       time.setAttribute('prefix', '')
       time.setAttribute('lang', 'en-US')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-02-01T00:00:00.000Z')
       await Promise.resolve()
       assert.match(time.shadowRoot.textContent, /[A-Z][a-z]{2} \d{1,2}/)
     })
@@ -757,189 +757,941 @@ suite('relative-time', function () {
     const referenceDate = '2022-10-24T14:46:00.000Z'
     const tests = new Set([
       // Same as the current time
-      {datetime: '2022-10-24T14:46:00.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:46:00.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'now'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'duration', expected: '0 seconds'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'duration', precision: 'minute', expected: '0 minutes'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'duration', precision: 'day', expected: '0 days'},
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'duration',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '0 minutes',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
 
       // A few seconds in the future
-      {datetime: '2022-10-24T14:46:08.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:46:08.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'relative', formatStyle: 'narrow', expected: 'now'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'duration', expected: '8 seconds'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'duration', precision: 'minute', expected: '0 minutes'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'duration', tense: 'future', expected: '8 seconds'},
-      {datetime: '2022-10-24T14:46:08.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'duration',
+        expected: '8 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '0 minutes',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '8 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:08.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // 50 seconds in the future
-      {datetime: '2022-10-24T14:46:50.000Z', tense: 'future', format: 'relative', expected: 'in 50 seconds'},
-      {datetime: '2022-10-24T14:46:50.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'relative', formatStyle: 'narrow', expected: 'in 50 sec.'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'duration', expected: '50 seconds'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'duration', precision: 'minute', expected: '0 minutes'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'duration', tense: 'future', expected: '50 seconds'},
-      {datetime: '2022-10-24T14:46:50.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'in 50 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'in 50 sec.',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'duration',
+        expected: '50 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '0 minutes',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '50 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:46:50.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // 90 seconds in the future
-      {datetime: '2022-10-24T14:47:30.000Z', tense: 'future', format: 'relative', expected: 'in 1 minute'},
-      {datetime: '2022-10-24T14:47:30.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'relative', formatStyle: 'narrow', expected: 'in 1 min.'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'duration', expected: '1 minute, 30 seconds'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'duration', precision: 'minute', expected: '1 minute'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'duration', tense: 'future', expected: '1 minute, 30 seconds'},
-      {datetime: '2022-10-24T14:47:30.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'in 1 minute',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'in 1 min.',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'duration',
+        expected: '1 minute, 30 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '1 minute',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '1 minute, 30 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:47:30.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // 20 days in the future
-      {datetime: '2022-11-13T15:46:00.000Z', tense: 'future', format: 'relative', expected: 'in 3 weeks'},
-      {datetime: '2022-11-13T15:46:00.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'in 3 wk.'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'relative', precision: 'hour', expected: 'in 3 weeks'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Nov 13'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'datetime', expected: 'Sun, Nov 13'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '13'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'duration', expected: '20 days, 1 hour'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'duration', precision: 'minute', expected: '20 days, 1 hour'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'duration', precision: 'day', expected: '20 days'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'duration', tense: 'future', expected: '20 days, 1 hour'},
-      {datetime: '2022-11-13T15:46:00.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'in 3 weeks',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'in 3 wk.',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'in 3 weeks',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Nov 13',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'datetime',
+        expected: 'Sun, Nov 13',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '13',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'duration',
+        expected: '20 days, 1 hour',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '20 days, 1 hour',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '20 days',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '20 days, 1 hour',
+      },
+      {
+        datetime: '2022-11-13T15:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // 40 days in the future
-      {datetime: '2022-12-03T15:46:00.000Z', tense: 'future', format: 'relative', expected: 'next month'},
-      {datetime: '2022-12-03T15:46:00.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'on Dec 3'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'relative', precision: 'hour', expected: 'on Dec 3'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Dec 3'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'datetime', expected: 'Sat, Dec 3'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '3'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'duration', expected: '1 month, 10 days, 1 hour'},
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'next month',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'on Dec 3',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'on Dec 3',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Dec 3',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'datetime',
+        expected: 'Sat, Dec 3',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '3',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'duration',
+        expected: '1 month, 10 days, 1 hour',
+      },
       {
         datetime: '2022-12-03T15:46:00.000Z',
         format: 'duration',
         precision: 'minute',
         expected: '1 month, 10 days, 1 hour',
       },
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'duration', precision: 'day', expected: '1 month, 10 days'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'duration', tense: 'future', expected: '1 month, 10 days, 1 hour'},
-      {datetime: '2022-12-03T15:46:00.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '1 month, 10 days',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '1 month, 10 days, 1 hour',
+      },
+      {
+        datetime: '2022-12-03T15:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // 2 years in the future
-      {datetime: '2024-10-24T14:46:00.000Z', tense: 'future', format: 'relative', expected: 'in 2 years'},
-      {datetime: '2024-10-24T14:46:00.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'on Oct 24, 2024'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'relative', precision: 'hour', expected: 'on Oct 24, 2024'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24, 2024'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'datetime', expected: 'Thu, Oct 24, 2024'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '2024 (day: 24)'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'duration', expected: '2 years, 11 days'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'duration', precision: 'minute', expected: '2 years, 11 days'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'duration', precision: 'day', expected: '2 years, 11 days'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'duration', tense: 'future', expected: '2 years, 11 days'},
-      {datetime: '2024-10-24T14:46:00.000Z', format: 'duration', tense: 'past', expected: '0 seconds'},
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'in 2 years',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'on Oct 24, 2024',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'on Oct 24, 2024',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24, 2024',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'datetime',
+        expected: 'Thu, Oct 24, 2024',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '2024 (day: 24)',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
+        expected: '2 years, 11 days',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '2 years, 11 days',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '2 years, 11 days',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '2 years, 11 days',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '0 seconds',
+      },
 
       // A few seconds in the past
-      {datetime: '2022-10-24T14:45:52.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:45:52.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'relative', formatStyle: 'narrow', expected: 'now'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'duration', expected: '8 seconds'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'duration', precision: 'minute', expected: '0 minutes'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2022-10-24T14:45:52.000Z', format: 'duration', tense: 'past', expected: '8 seconds'},
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'duration',
+        expected: '8 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '0 minutes',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:45:52.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '8 seconds',
+      },
 
       // 50 seconds in the past
-      {datetime: '2022-10-24T14:45:10.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:45:10.000Z', tense: 'past', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'relative', formatStyle: 'narrow', expected: 'now'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'duration', expected: '50 seconds'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'duration', precision: 'minute', expected: '0 minutes'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2022-10-24T14:45:10.000Z', format: 'duration', tense: 'past', expected: '50 seconds'},
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'duration',
+        expected: '50 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '0 minutes',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:45:10.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '50 seconds',
+      },
 
       // 90 seconds in the past
-      {datetime: '2022-10-24T14:44:30.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-24T14:44:30.000Z', tense: 'past', format: 'relative', expected: '1 minute ago'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'relative', formatStyle: 'narrow', expected: '1 min. ago'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'relative', precision: 'hour', expected: 'now'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'datetime', expected: 'Mon, Oct 24'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'datetime', weekday: '', month: '', expected: '24'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'duration', expected: '1 minute, 30 seconds'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'duration', precision: 'minute', expected: '1 minute'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'duration', precision: 'day', expected: '0 days'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2022-10-24T14:44:30.000Z', format: 'duration', tense: 'past', expected: '1 minute, 30 seconds'},
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: '1 minute ago',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: '1 min. ago',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'datetime',
+        expected: 'Mon, Oct 24',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '24',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'duration',
+        expected: '1 minute, 30 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '1 minute',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '0 days',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-10-24T14:44:30.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '1 minute, 30 seconds',
+      },
 
       // 20 days in the past
-      {datetime: '2022-10-04T14:46:00.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-10-04T14:46:00.000Z', tense: 'past', format: 'relative', expected: '3 weeks ago'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: '3 wk. ago'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'relative', precision: 'hour', expected: '3 weeks ago'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 4'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'datetime', expected: 'Tue, Oct 4'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '4'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'duration', expected: '20 days'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'duration', precision: 'minute', expected: '20 days'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'duration', precision: 'day', expected: '20 days'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2022-10-04T14:46:00.000Z', format: 'duration', tense: 'past', expected: '20 days'},
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: '3 weeks ago',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: '3 wk. ago',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: '3 weeks ago',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 4',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'datetime',
+        expected: 'Tue, Oct 4',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '4',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'duration',
+        expected: '20 days',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '20 days',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '20 days',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-10-04T14:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '20 days',
+      },
 
       // 40 days in the past
-      {datetime: '2022-09-14T14:46:00.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2022-09-14T14:46:00.000Z', tense: 'past', format: 'relative', expected: 'last month'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'on Sep 14'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'relative', precision: 'hour', expected: 'on Sep 14'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Sep 14'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'datetime', expected: 'Wed, Sep 14'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '14'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'duration', expected: '1 month, 10 days'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'duration', precision: 'minute', expected: '1 month, 10 days'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'duration', precision: 'day', expected: '1 month, 10 days'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2022-09-14T14:46:00.000Z', format: 'duration', tense: 'past', expected: '1 month, 10 days'},
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: 'last month',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'on Sep 14',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'on Sep 14',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Sep 14',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'datetime',
+        expected: 'Wed, Sep 14',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '14',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'duration',
+        expected: '1 month, 10 days',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '1 month, 10 days',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '1 month, 10 days',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2022-09-14T14:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '1 month, 10 days',
+      },
 
       // 2 years in the past
-      {datetime: '2020-10-24T14:46:00.000Z', tense: 'future', format: 'relative', expected: 'now'},
-      {datetime: '2020-10-24T14:46:00.000Z', tense: 'past', format: 'relative', expected: '2 years ago'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'relative', formatStyle: 'narrow', expected: 'on Oct 24, 2020'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'relative', precision: 'hour', expected: 'on Oct 24, 2020'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'relative', threshold: 'PT0S', expected: 'on Oct 24, 2020'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'datetime', expected: 'Sat, Oct 24, 2020'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'datetime', weekday: '', month: '', expected: '2020 (day: 24)'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'duration', expected: '2 years, 10 days'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'duration', precision: 'minute', expected: '2 years, 10 days'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'duration', precision: 'day', expected: '2 years, 10 days'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'duration', tense: 'future', expected: '0 seconds'},
-      {datetime: '2020-10-24T14:46:00.000Z', format: 'duration', tense: 'past', expected: '2 years, 10 days'},
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'relative',
+        expected: 'now',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'relative',
+        expected: '2 years ago',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'relative',
+        formatStyle: 'narrow',
+        expected: 'on Oct 24, 2020',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'relative',
+        precision: 'hour',
+        expected: 'on Oct 24, 2020',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'relative',
+        threshold: 'PT0S',
+        expected: 'on Oct 24, 2020',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'datetime',
+        expected: 'Sat, Oct 24, 2020',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'datetime',
+        weekday: '',
+        month: '',
+        expected: '2020 (day: 24)',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'duration',
+        expected: '2 years, 10 days',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'minute',
+        expected: '2 years, 10 days',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'duration',
+        precision: 'day',
+        expected: '2 years, 10 days',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'duration',
+        tense: 'future',
+        expected: '0 seconds',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'duration',
+        tense: 'past',
+        expected: '2 years, 10 days',
+      },
     ])
 
     for (const {
@@ -955,9 +1707,13 @@ suite('relative-time', function () {
       lang = 'en',
       reference = referenceDate,
     } of tests) {
-      const attrs = Object.entries({datetime, tense, format, formatStyle, precision}).map(([k, v]) =>
-        v ? `${k}="${v}"` : '',
-      )
+      const attrs = Object.entries({
+        datetime,
+        tense,
+        format,
+        formatStyle,
+        precision,
+      }).map(([k, v]) => (v ? `${k}="${v}"` : ''))
       test(`<relative-time ${attrs.join(' ')}> => ${expected}`, async () => {
         freezeTime(new Date(reference))
         const time = document.createElement('relative-time')
@@ -980,117 +1736,590 @@ suite('relative-time', function () {
     const referenceDate = '2022-10-24T14:46:00.000Z'
     const tests = new Set([
       // Same as the current time
-      {datetime: '2022-10-24T14:46:00.000z', tense: 'future', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-24T14:46:00.000z', tense: 'past', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-24T14:46:00.000z', tense: 'auto', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-24T14:46:00.000z', tense: 'auto', format: 'auto', expected: 'now'},
+      {
+        datetime: '2022-10-24T14:46:00.000z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000z',
+        tense: 'auto',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T14:46:00.000z',
+        tense: 'auto',
+        format: 'auto',
+        expected: 'now',
+      },
 
       // Dates in the past
-      {datetime: '2022-09-24T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-23T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-24T13:46:00.000Z', tense: 'future', format: 'micro', expected: '1m'},
+      {
+        datetime: '2022-09-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-23T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T13:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1m',
+      },
 
       // Dates in the future
-      {datetime: '2022-10-24T15:46:00.000Z', tense: 'future', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T16:00:00.000Z', tense: 'future', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T16:15:00.000Z', tense: 'future', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T16:31:00.000Z', tense: 'future', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-30T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1w'},
-      {datetime: '2022-11-24T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1m'},
-      {datetime: '2023-10-23T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1y'},
-      {datetime: '2023-10-24T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1y'},
-      {datetime: '2024-03-31T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1y'},
-      {datetime: '2024-04-01T14:46:00.000Z', tense: 'future', format: 'micro', expected: '1y'},
+      {
+        datetime: '2022-10-24T15:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T16:00:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T16:15:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T16:31:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-30T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1w',
+      },
+      {
+        datetime: '2022-11-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2023-10-23T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2023-10-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2024-03-31T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2024-04-01T14:46:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '1y',
+      },
 
       // Dates in the future
-      {datetime: '2022-11-24T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-25T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1m'},
-      {datetime: '2022-10-24T15:46:00.000Z', tense: 'past', format: 'micro', expected: '1m'},
+      {
+        datetime: '2022-11-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-25T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T15:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1m',
+      },
 
       // Dates in the past
-      {datetime: '2022-10-24T13:46:00.000Z', tense: 'past', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T13:30:00.000Z', tense: 'past', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T13:17:00.000Z', tense: 'past', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-24T13:01:00.000Z', tense: 'past', format: 'micro', expected: '1h'},
-      {datetime: '2022-10-18T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1w'},
-      {datetime: '2022-09-23T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1m'},
-      {datetime: '2021-10-25T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1y'},
-      {datetime: '2021-10-24T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1y'},
-      {datetime: '2021-05-18T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1y'},
-      {datetime: '2021-05-17T14:46:00.000Z', tense: 'past', format: 'micro', expected: '1y'},
+      {
+        datetime: '2022-10-24T13:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T13:30:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T13:17:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-24T13:01:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1h',
+      },
+      {
+        datetime: '2022-10-18T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1w',
+      },
+      {
+        datetime: '2022-09-23T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1m',
+      },
+      {
+        datetime: '2021-10-25T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2021-10-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2021-05-18T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1y',
+      },
+      {
+        datetime: '2021-05-17T14:46:00.000Z',
+        tense: 'past',
+        format: 'micro',
+        expected: '1y',
+      },
 
       // Elapsed Times
-      {datetime: '2022-10-24T14:46:10.000Z', format: 'elapsed', expected: '10s'},
-      {datetime: '2022-10-24T14:45:50.000Z', format: 'elapsed', expected: '10s'},
-      {datetime: '2022-10-24T14:45:50.000Z', format: 'elapsed', precision: 'minute', expected: '0m'},
-      {datetime: '2022-10-24T14:47:40.000Z', format: 'elapsed', expected: '1m 40s'},
-      {datetime: '2022-10-24T14:44:20.000Z', format: 'elapsed', expected: '1m 40s'},
-      {datetime: '2022-10-24T14:44:20.000Z', format: 'elapsed', precision: 'minute', expected: '1m'},
-      {datetime: '2022-10-24T15:51:40.000Z', format: 'elapsed', expected: '1h 5m 40s'},
-      {datetime: '2022-10-24T15:51:40.000Z', format: 'elapsed', precision: 'minute', expected: '1h 5m'},
-      {datetime: '2022-10-24T15:52:00.000Z', format: 'elapsed', expected: '1h 6m'},
-      {datetime: '2022-10-24T17:46:00.000Z', format: 'elapsed', expected: '3h'},
-      {datetime: '2022-10-24T10:46:00.000Z', format: 'elapsed', expected: '4h'},
-      {datetime: '2022-10-25T18:46:00.000Z', format: 'elapsed', expected: '1d 4h'},
-      {datetime: '2022-10-23T10:46:00.000Z', format: 'elapsed', expected: '1d 4h'},
-      {datetime: '2022-10-23T10:46:00.000Z', format: 'elapsed', precision: 'day', expected: '1d'},
-      {datetime: '2021-10-30T14:46:00.000Z', format: 'elapsed', expected: '11m 29d'},
-      {datetime: '2021-10-30T14:46:00.000Z', format: 'elapsed', precision: 'month', expected: '11m'},
-      {datetime: '2021-10-29T14:46:00.000Z', format: 'elapsed', expected: '1y'},
+      {
+        datetime: '2022-10-24T14:46:10.000Z',
+        format: 'elapsed',
+        expected: '10s',
+      },
+      {
+        datetime: '2022-10-24T14:45:50.000Z',
+        format: 'elapsed',
+        expected: '10s',
+      },
+      {
+        datetime: '2022-10-24T14:45:50.000Z',
+        format: 'elapsed',
+        precision: 'minute',
+        expected: '0m',
+      },
+      {
+        datetime: '2022-10-24T14:47:40.000Z',
+        format: 'elapsed',
+        expected: '1m 40s',
+      },
+      {
+        datetime: '2022-10-24T14:44:20.000Z',
+        format: 'elapsed',
+        expected: '1m 40s',
+      },
+      {
+        datetime: '2022-10-24T14:44:20.000Z',
+        format: 'elapsed',
+        precision: 'minute',
+        expected: '1m',
+      },
+      {
+        datetime: '2022-10-24T15:51:40.000Z',
+        format: 'elapsed',
+        expected: '1h 5m 40s',
+      },
+      {
+        datetime: '2022-10-24T15:51:40.000Z',
+        format: 'elapsed',
+        precision: 'minute',
+        expected: '1h 5m',
+      },
+      {
+        datetime: '2022-10-24T15:52:00.000Z',
+        format: 'elapsed',
+        expected: '1h 6m',
+      },
+      {
+        datetime: '2022-10-24T17:46:00.000Z',
+        format: 'elapsed',
+        expected: '3h',
+      },
+      {
+        datetime: '2022-10-24T10:46:00.000Z',
+        format: 'elapsed',
+        expected: '4h',
+      },
+      {
+        datetime: '2022-10-25T18:46:00.000Z',
+        format: 'elapsed',
+        expected: '1d 4h',
+      },
+      {
+        datetime: '2022-10-23T10:46:00.000Z',
+        format: 'elapsed',
+        expected: '1d 4h',
+      },
+      {
+        datetime: '2022-10-23T10:46:00.000Z',
+        format: 'elapsed',
+        precision: 'day',
+        expected: '1d',
+      },
+      {
+        datetime: '2021-10-30T14:46:00.000Z',
+        format: 'elapsed',
+        expected: '11m 29d',
+      },
+      {
+        datetime: '2021-10-30T14:46:00.000Z',
+        format: 'elapsed',
+        precision: 'month',
+        expected: '11m',
+      },
+      {
+        datetime: '2021-10-29T14:46:00.000Z',
+        format: 'elapsed',
+        expected: '1y',
+      },
 
       // Dates in the past
-      {datetime: '2022-09-24T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'now'},
-      {datetime: '2022-10-23T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'now'},
-      {datetime: '2022-10-24T13:46:00.000Z', tense: 'future', format: 'auto', expected: 'now'},
+      {
+        datetime: '2022-09-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-23T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T13:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'now',
+      },
 
       // Dates in the future
-      {datetime: '2022-10-24T15:46:00.000Z', tense: 'future', format: 'auto', expected: 'in 1 hour'},
-      {datetime: '2022-10-24T16:00:00.000Z', tense: 'future', format: 'auto', expected: 'in 1 hour'},
-      {datetime: '2022-10-24T16:15:00.000Z', tense: 'future', format: 'auto', expected: 'in 1 hour'},
-      {datetime: '2022-10-24T16:31:00.000Z', tense: 'future', format: 'auto', expected: 'in 1 hour'},
-      {datetime: '2022-10-30T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next week'},
-      {datetime: '2022-11-24T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next month'},
-      {datetime: '2023-10-23T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
-      {datetime: '2023-10-24T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
-      {datetime: '2024-03-31T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
-      {datetime: '2024-04-01T14:46:00.000Z', tense: 'future', format: 'auto', expected: 'next year'},
-      {datetime: '2022-10-24T15:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
-      {datetime: '2022-10-24T16:00:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
-      {datetime: '2022-10-24T16:15:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
-      {datetime: '2022-10-24T16:31:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'in 1 hr.'},
-      {datetime: '2022-10-30T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next wk.'},
-      {datetime: '2022-11-24T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next mo.'},
-      {datetime: '2023-10-23T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
-      {datetime: '2023-10-24T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
-      {datetime: '2024-03-31T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
-      {datetime: '2024-04-01T14:46:00.000Z', lang: 'en', tense: 'future', formatStyle: 'narrow', expected: 'next yr.'},
+      {
+        datetime: '2022-10-24T15:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'in 1 hour',
+      },
+      {
+        datetime: '2022-10-24T16:00:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'in 1 hour',
+      },
+      {
+        datetime: '2022-10-24T16:15:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'in 1 hour',
+      },
+      {
+        datetime: '2022-10-24T16:31:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'in 1 hour',
+      },
+      {
+        datetime: '2022-10-30T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next week',
+      },
+      {
+        datetime: '2022-11-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next month',
+      },
+      {
+        datetime: '2023-10-23T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next year',
+      },
+      {
+        datetime: '2023-10-24T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next year',
+      },
+      {
+        datetime: '2024-03-31T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next year',
+      },
+      {
+        datetime: '2024-04-01T14:46:00.000Z',
+        tense: 'future',
+        format: 'auto',
+        expected: 'next year',
+      },
+      {
+        datetime: '2022-10-24T15:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'in 1 hr.',
+      },
+      {
+        datetime: '2022-10-24T16:00:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'in 1 hr.',
+      },
+      {
+        datetime: '2022-10-24T16:15:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'in 1 hr.',
+      },
+      {
+        datetime: '2022-10-24T16:31:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'in 1 hr.',
+      },
+      {
+        datetime: '2022-10-30T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next wk.',
+      },
+      {
+        datetime: '2022-11-24T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next mo.',
+      },
+      {
+        datetime: '2023-10-23T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next yr.',
+      },
+      {
+        datetime: '2023-10-24T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next yr.',
+      },
+      {
+        datetime: '2024-03-31T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next yr.',
+      },
+      {
+        datetime: '2024-04-01T14:46:00.000Z',
+        lang: 'en',
+        tense: 'future',
+        formatStyle: 'narrow',
+        expected: 'next yr.',
+      },
 
       // Dates in the future
-      {datetime: '2022-11-24T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'now'},
-      {datetime: '2022-10-25T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'now'},
-      {datetime: '2022-10-24T15:46:00.000Z', tense: 'past', format: 'auto', expected: 'now'},
+      {
+        datetime: '2022-11-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-25T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'now',
+      },
+      {
+        datetime: '2022-10-24T15:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'now',
+      },
 
       // Dates in the past
-      {datetime: '2022-10-24T13:46:00.000Z', tense: 'past', format: 'auto', expected: '1 hour ago'},
-      {datetime: '2022-10-24T13:30:00.000Z', tense: 'past', format: 'auto', expected: '1 hour ago'},
-      {datetime: '2022-10-24T13:17:00.000Z', tense: 'past', format: 'auto', expected: '1 hour ago'},
-      {datetime: '2022-10-24T13:01:00.000Z', tense: 'past', format: 'auto', expected: '1 hour ago'},
-      {datetime: '2022-10-18T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last week'},
-      {datetime: '2022-09-23T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last month'},
-      {datetime: '2021-10-25T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last year'},
-      {datetime: '2021-10-24T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last year'},
-      {datetime: '2021-05-18T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last year'},
-      {datetime: '2021-05-17T14:46:00.000Z', tense: 'past', format: 'auto', expected: 'last year'},
-      {datetime: '2022-10-24T13:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
-      {datetime: '2022-10-24T13:30:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
-      {datetime: '2022-10-24T13:17:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
-      {datetime: '2022-10-24T13:01:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: '1 hr. ago'},
-      {datetime: '2022-10-18T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last wk.'},
-      {datetime: '2022-09-23T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last mo.'},
-      {datetime: '2021-10-25T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last yr.'},
-      {datetime: '2021-10-24T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last yr.'},
-      {datetime: '2021-05-18T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last yr.'},
-      {datetime: '2021-05-17T14:46:00.000Z', lang: 'en', tense: 'past', formatStyle: 'narrow', expected: 'last yr.'},
+      {
+        datetime: '2022-10-24T13:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: '1 hour ago',
+      },
+      {
+        datetime: '2022-10-24T13:30:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: '1 hour ago',
+      },
+      {
+        datetime: '2022-10-24T13:17:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: '1 hour ago',
+      },
+      {
+        datetime: '2022-10-24T13:01:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: '1 hour ago',
+      },
+      {
+        datetime: '2022-10-18T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last week',
+      },
+      {
+        datetime: '2022-09-23T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last month',
+      },
+      {
+        datetime: '2021-10-25T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last year',
+      },
+      {
+        datetime: '2021-10-24T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last year',
+      },
+      {
+        datetime: '2021-05-18T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last year',
+      },
+      {
+        datetime: '2021-05-17T14:46:00.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: 'last year',
+      },
+      {
+        datetime: '2022-10-24T13:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: '1 hr. ago',
+      },
+      {
+        datetime: '2022-10-24T13:30:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: '1 hr. ago',
+      },
+      {
+        datetime: '2022-10-24T13:17:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: '1 hr. ago',
+      },
+      {
+        datetime: '2022-10-24T13:01:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: '1 hr. ago',
+      },
+      {
+        datetime: '2022-10-18T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last wk.',
+      },
+      {
+        datetime: '2022-09-23T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last mo.',
+      },
+      {
+        datetime: '2021-10-25T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last yr.',
+      },
+      {
+        datetime: '2021-10-24T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last yr.',
+      },
+      {
+        datetime: '2021-05-18T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last yr.',
+      },
+      {
+        datetime: '2021-05-17T14:46:00.000Z',
+        lang: 'en',
+        tense: 'past',
+        formatStyle: 'narrow',
+        expected: 'last yr.',
+      },
 
       // Edge case dates
       {
@@ -1140,9 +2369,13 @@ suite('relative-time', function () {
       lang,
       reference = referenceDate,
     } of tests) {
-      const attrs = Object.entries({datetime, tense, format, formatStyle, precision}).map(([k, v]) =>
-        v ? `${k}="${v}"` : '',
-      )
+      const attrs = Object.entries({
+        datetime,
+        tense,
+        format,
+        formatStyle,
+        precision,
+      }).map(([k, v]) => (v ? `${k}="${v}"` : ''))
       test(`<relative-time ${attrs.join(' ')}> => ${expected}`, async () => {
         freezeTime(new Date(reference))
         const time = document.createElement('relative-time')

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1834,13 +1834,13 @@ suite('relative-time', function () {
         datetime: '2024-03-31T14:46:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '1y',
+        expected: '2y',
       },
       {
         datetime: '2024-04-01T14:46:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '1y',
+        expected: '2y',
       },
 
       // Dates in the future
@@ -2090,13 +2090,13 @@ suite('relative-time', function () {
         datetime: '2024-03-31T14:46:00.000Z',
         tense: 'future',
         format: 'auto',
-        expected: 'next year',
+        expected: 'in 2 years',
       },
       {
         datetime: '2024-04-01T14:46:00.000Z',
         tense: 'future',
         format: 'auto',
-        expected: 'next year',
+        expected: 'in 2 years',
       },
       {
         datetime: '2022-10-24T15:46:00.000Z',
@@ -2159,14 +2159,14 @@ suite('relative-time', function () {
         lang: 'en',
         tense: 'future',
         formatStyle: 'narrow',
-        expected: 'next yr.',
+        expected: 'in 2 yr.',
       },
       {
         datetime: '2024-04-01T14:46:00.000Z',
         lang: 'en',
         tense: 'future',
         formatStyle: 'narrow',
-        expected: 'next yr.',
+        expected: 'in 2 yr.',
       },
 
       // Dates in the future
@@ -2348,14 +2348,21 @@ suite('relative-time', function () {
         datetime: '2024-03-01T12:00:00.000Z',
         tense: 'future',
         format: 'auto',
-        expected: 'next year',
+        expected: 'in 2 years',
       },
       {
         reference: '2022-12-31T12:00:00.000Z',
         datetime: '2024-03-01T12:00:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '1y',
+        expected: '2y',
+      },
+      {
+        reference: '2021-04-24T12:00:00.000Z',
+        datetime: '2023-02-01T12:00:00.000Z',
+        tense: 'future',
+        format: 'micro',
+        expected: '2y',
       },
     ])
 

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -419,12 +419,12 @@ suite('relative-time', function () {
 
   suite('[tense=past]', function () {
     test('always uses relative dates', async () => {
-      const now = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
+      freezeTime(new Date(2033, 1, 1))
       const time = document.createElement('relative-time')
       time.setAttribute('tense', 'past')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-01-01T00:00:00Z')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '10 years ago')
+      assert.equal(time.shadowRoot.textContent, '11 years ago')
     })
 
     test('rewrites from now past datetime to minutes ago', async () => {
@@ -466,32 +466,12 @@ suite('relative-time', function () {
     })
 
     test('rewrites from now past datetime to months ago', async () => {
-      const now = new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000).toISOString()
+      freezeTime(new Date(2023, 8, 1))
       const time = document.createElement('relative-time')
       time.setAttribute('tense', 'past')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2023-06-01T00:00:00Z')
       await Promise.resolve()
       assert.equal(time.shadowRoot.textContent, '3 months ago')
-    })
-
-    test('rewrites relative-time datetimes < 18 months as "last year"', async () => {
-      freezeTime(new Date(2020, 0, 1))
-      const then = new Date(2018, 9, 1).toISOString()
-      const timeElement = document.createElement('relative-time')
-      timeElement.setAttribute('tense', 'past')
-      timeElement.setAttribute('datetime', then)
-      await Promise.resolve()
-      assert.equal(timeElement.shadowRoot.textContent, 'last year')
-    })
-
-    test('rewrites relative-time datetimes >= 18 months as "years ago"', async () => {
-      freezeTime(new Date(2020, 0, 1))
-      const then = new Date(2018, 6, 1).toISOString()
-      const timeElement = document.createElement('relative-time')
-      timeElement.setAttribute('tense', 'past')
-      timeElement.setAttribute('datetime', then)
-      await Promise.resolve()
-      assert.equal(timeElement.shadowRoot.textContent, 'last year')
     })
 
     test('micro formats years', async () => {
@@ -501,7 +481,7 @@ suite('relative-time', function () {
       time.setAttribute('datetime', now)
       time.setAttribute('format', 'micro')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '10y')
+      assert.equal(time.shadowRoot.textContent, '11y')
     })
 
     test('micro formats future times', async () => {
@@ -537,10 +517,10 @@ suite('relative-time', function () {
 
   suite('[tense=future]', function () {
     test('always uses relative dates', async () => {
-      const now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
+      freezeTime(new Date(2023, 1, 1))
       const time = document.createElement('relative-time')
       time.setAttribute('tense', 'future')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', '2033-01-01T00:00:00Z')
       await Promise.resolve()
       assert.equal(time.shadowRoot.textContent, 'in 10 years')
     })


### PR DESCRIPTION
Currently the main release of relative time uses a 90% rounding rule for dates.

Relative times are colloquial and so every user interprets them in subtly different ways. There are a few techniques we have used in the past:

 - We go on the literal date unit. So at 12:01AM a post from 2 minutes prior would say "a day ago". A post on the 31st December, when read on 1st Jan, would say "last year", which feels inaccurate.
 - We round units to some amount, so if the delta is 2 minutes we say "2 minutes ago" until minutes can be rounded up to hours at which point we can say "1 hour ago". We can pick the threshold for this...
   - A threshold of 50% would mean something 30 minutes ago would be "1 hour ago", and something 6 months ago would say "last year". Having a low threshold for larger durations seems inaccurate.
   - A threshold of 90% would mean something 54 minutes ago would be "1 hour ago", something 11 months ago would be "last year".  The downside to this is that occasionally you'll get rounding such as something being 20 months old saying "last year". Having a high threshold seems inaccurate.

Right now the 90% threshold is our latest iteration but it has problems with large units of time, chiefly months and years. At the time of writing, for example, dates from April 2021 will be marked as "last year" despite being much closer to "2 years ago".

This PR changes the logic _just for months and years_ to use a similar mechanism to that described in [`Temporal.Duration.round`](https://tc39.es/proposal-temporal/docs/duration.html#round). We take the `relativeTo` which is a date, and we execute calendar math on the date object - working out the delta of the current month and rounding based on calendar year instead of a rounding of months.

This means for dates that have a delta of months or years, they will perform calendar operations, and those dates will be relative to the calendar year. In other words a date from 2022 read in 2023 will only ever read as "last year" and not "2 years ago", meanwhile a date from 2021 read in 2023 will never say "last year" and will always say "2 years ago". 