### PR TITLE
fix: fixes round to string unit

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -155,12 +155,14 @@ export function roundToSingleUnit(duration: Duration, {relativeTo = Date.now()}:
   const currentDate = relativeTo.getDate()
   if (days >= 27 || (years + months && days)) {
     relativeTo.setDate(currentDate + days * sign)
-    days = 0
     months += Math.abs(
       relativeTo.getFullYear() >= currentYear
         ? relativeTo.getMonth() - currentMonth
         : relativeTo.getMonth() - currentMonth - 12,
     )
+    if (months) {
+      days = 0
+    }
     currentMonth = relativeTo.getMonth()
   }
 

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -301,6 +301,7 @@ suite('duration', function () {
           relativeTo: new Date('2022-01-01T00:00:00Z'),
         },
       ],
+      ['-P27D', '-P1M', {relativeTo: new Date('2023-02-28T00:00:00Z')}],
     ])
     for (const [input, expected, opts] of roundTests) {
       test(`roundToSingleUnit(${input}) === ${expected}`, () => {


### PR DESCRIPTION
Fixes round to single unit function returns `nows` when durations exceeds -27 days in the same month.