### PR TITLE
fix aggressive compression of hours into a single day

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -147,7 +147,8 @@ export function roundToSingleUnit(duration: Duration, {relativeTo = Date.now()}:
   if (minutes >= 55) hours += Math.round(minutes / 60)
   if (hours || days || weeks || months || years) minutes = 0
 
-  if (hours >= 21) days += Math.round(hours / 24)
+  if (days && hours >= 12) days += Math.round(hours / 24)
+  if (!days && hours >= 21) days += Math.round(hours / 24)
   if (days || weeks || months || years) hours = 0
 
   const currentYear = relativeTo.getFullYear()

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -215,6 +215,11 @@ suite('duration', function () {
         input: '2021-10-29T14:46:00.000Z',
         expected: '-P1Y',
       },
+      {
+        now: '2023-03-23T12:03:00.000Z',
+        input: '2023-03-21T16:03:00.000Z',
+        expected: '-P1DT20H',
+      },
     ])
     for (const {input, now, precision = 'millisecond', expected} of elapsed) {
       test(`${input} is ${expected} elapsed from ${now} (precision ${precision})`, () => {
@@ -235,6 +240,8 @@ suite('duration', function () {
       ['PT1H55M', 'PT2H'],
       ['PT20H', 'PT20H'],
       ['PT21H', 'P1D'],
+      ['P1DT20H', 'P2D'],
+      ['P1DT18H', 'P2D'],
       ['P4D', 'P4D', {relativeTo: new Date('2023-07-01T00:00:00')}],
       ['-P4D', '-P4D', {relativeTo: new Date('2023-07-01T00:00:00')}],
       ['P6D', 'P1W', {relativeTo: new Date('2023-07-01T00:00:00')}],

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1752,6 +1752,13 @@ suite('relative-time', function () {
         tense: 'past',
         expected: '2 years, 10 days',
       },
+      {
+        reference: '2023-03-23T12:03:00.000Z',
+        datetime: '2023-03-21T16:03:00.000Z',
+        format: 'relative',
+        tense: 'past',
+        expected: '2 days ago',
+      },
     ])
 
     for (const {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -475,13 +475,14 @@ suite('relative-time', function () {
     })
 
     test('micro formats years', async () => {
-      const now = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
+      const datetime = new Date()
+      datetime.setFullYear(datetime.getFullYear() - 10)
       const time = document.createElement('relative-time')
       time.setAttribute('tense', 'past')
-      time.setAttribute('datetime', now)
+      time.setAttribute('datetime', datetime)
       time.setAttribute('format', 'micro')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '11y')
+      assert.equal(time.shadowRoot.textContent, '10y')
     })
 
     test('micro formats future times', async () => {


### PR DESCRIPTION
Some nearby dates get aggressively compressed to `yesterday` when they're over 1 day away (e.g. something that is 1 day and 20 hours ago will say `yesterday` when it probably should say `2 days ago`).

This fixes that.