### PR TITLE
round years using calendar years only

### DIFF
--- a/test/duration.ts
+++ b/test/duration.ts
@@ -293,6 +293,7 @@ suite('duration', function () {
       ['P9M20DT25H', 'P10M', {relativeTo: new Date('2023-01-12T00:00:00Z')}],
       ['P11M', 'P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
       ['-P11M', '-P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
+      ['-P11M15D', '-P1Y', {relativeTo: new Date('2024-01-06T00:00:00')}],
       ['P1Y4D', 'P1Y', {relativeTo: new Date('2022-11-01T00:00:00Z')}],
       ['P1Y5M13D', 'P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
       ['P1Y5M15D', 'P1Y', {relativeTo: new Date('2023-01-01T00:00:00Z')}],
@@ -308,7 +309,12 @@ suite('duration', function () {
           relativeTo: new Date('2022-01-01T00:00:00Z'),
         },
       ],
-      ['-P27D', '-P1M', {relativeTo: new Date('2023-02-28T00:00:00Z')}],
+      ['-P27D', '-P27D', {relativeTo: new Date('2023-02-28T00:00:00Z')}],
+      ['-P27D', '-P1M', {relativeTo: new Date('2023-02-27T00:00:00Z')}],
+      ['P1Y2M1D', 'P2Y', {relativeTo: new Date('2022-12-31T12:00:00.000Z')}],
+      ['-P1Y8D', '-P1Y', {relativeTo: new Date('2024-01-11T12:00:00.000Z')}],
+      ['-P1Y7DT19H43M19S', '-P1Y', {relativeTo: new Date('2024-01-11T12:00:00.000Z')}],
+      ['-P1Y11D', '-P2Y', {relativeTo: new Date('2024-01-11T12:00:00.000Z')}],
     ])
     for (const [input, expected, opts] of roundTests) {
       test(`roundToSingleUnit(${input}) === ${expected}`, () => {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -482,7 +482,7 @@ suite('relative-time', function () {
       time.setAttribute('datetime', datetime)
       time.setAttribute('format', 'micro')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '10y')
+      assert.equal(time.shadowRoot.textContent, '11y')
     })
 
     test('micro formats future times', async () => {
@@ -2416,14 +2416,14 @@ suite('relative-time', function () {
         datetime: '2024-03-01T12:00:00.000Z',
         tense: 'future',
         format: 'auto',
-        expected: 'in 3 years',
+        expected: 'in 2 years',
       },
       {
         reference: '2022-12-31T12:00:00.000Z',
         datetime: '2024-03-01T12:00:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '3y',
+        expected: '2y',
       },
       {
         reference: '2021-04-24T12:00:00.000Z',
@@ -2431,6 +2431,13 @@ suite('relative-time', function () {
         tense: 'future',
         format: 'micro',
         expected: '2y',
+      },
+      {
+        reference: '2024-01-04T12:00:00.000Z',
+        datetime: '2020-02-16T16:16:41.000Z',
+        tense: 'past',
+        format: 'auto',
+        expected: '4 years ago',
       },
     ])
 


### PR DESCRIPTION
Fixes #270

This uses calendar math for differences with a larger precision than 27 days.