### PR TITLE
upgrade ES target to es2022

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --ext .js,.ts && tsc --noEmit",
     "lint:fix": "npm run lint -- --fix",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
-    "bundle": "esbuild --bundle dist/index.js --keep-names --outfile=dist/bundle.js --format=esm",
+    "bundle": "esbuild --target=es2022 --bundle dist/index.js --keep-names --outfile=dist/bundle.js --format=esm",
     "build": "tsc && npm run bundle && npm run manifest",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "es2020",
-    "target": "es2017",
+    "module": "es2022",
+    "target": "es2022",
     "strict": true,
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
This upgrades the output to use ES2022. This includes native private fields syntax. We see almost zero devices on github.com that do not support private fields. And we've been [considered private fields part of our baseline support](https://github.github.com/browser-support/) for a while now.

This means users on macos Mojave and below, using Safari, may have a further degraded experience than they already have. They can improve their experience by switching to another browser such as Chrome or Firefox, but Apple does not release Safari 15 for macos Mojave or below, as Apple has not supported macOS Mojave since Oct 2021 - when it was EOLd.

This also means users on ios/ipados 14 may see a further degraded experience. ios/ipados 14 was EOL in October 2021, and Apple no longer provides security updates for these devices. Some of these devices can upgrade to ios/ipados 15. Some devices, like the iPad Mini 3 (discontinued October 2014), 4th generation iPad (discontinued October 2014), or the iPhone 6 (discontinued September 2016) will be unable to upgrade to iOS 15, and so visiting a page with `<relative-time>` will cause JS to `SyntaxError`.