### PR TITLE
Fix default value of `lang`

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ For dates outside of the specified `threshold`, the formatting of the date can b
 
 ##### lang
 
-Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang). Relative Time will use this to provide an applicable language to the `Intl` APIs. If the individual element does not have a `lang` attribute then it will traverse upwards in the tree to find the closest element that does, or default the lang to `en`.
+Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang). Relative Time will use this to provide an applicable language to the `Intl` APIs. If the individual element does not have a `lang` attribute then it will traverse upwards in the tree to find the closest element that does, or default the lang to `unknown`.
 
 ## Browser Support
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -85,7 +85,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return (
       this.closest('[lang]')?.getAttribute('lang') ||
       this.ownerDocument.documentElement.getAttribute('lang') ||
-      'default'
+      'unknown'
     )
   }
 


### PR DESCRIPTION
As per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang):

> The default value of `lang` is `unknown`

I'm pretty sure the previous value `default` was actually invalid.

