### PR TITLE
Run `npx eslint . --ext .js,.ts --fix`

### DIFF
--- a/src/duration-format-ponyfill.ts
+++ b/src/duration-format-ponyfill.ts
@@ -108,8 +108,8 @@ export default class DurationFormat {
         unitStyle === '2-digit'
           ? twoDigitFormatOptions
           : unitStyle === 'numeric'
-          ? {}
-          : {style: 'unit', unit: nfUnit, unitDisplay: unitStyle}
+            ? {}
+            : {style: 'unit', unit: nfUnit, unitDisplay: unitStyle}
       list.push(new Intl.NumberFormat(locale, nfOpts).format(value))
     }
     return new ListFormat(locale, {

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -2,7 +2,7 @@ import DurationFormat from './duration-format-ponyfill.js'
 import type {DurationFormatOptions} from './duration-format-ponyfill.js'
 const durationRe = /^[-+]?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
 export const unitNames = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'] as const
-export type Unit = typeof unitNames[number]
+export type Unit = (typeof unitNames)[number]
 
 export const isDuration = (str: string) => durationRe.test(str)
 type Sign = -1 | 0 | 1

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -1,5 +1,5 @@
 import {Duration, elapsedTime, getRelativeTimeUnit, isDuration, roundToSingleUnit, Unit, unitNames} from './duration.js'
-const HTMLElement = globalThis.HTMLElement || (null as unknown as typeof window['HTMLElement'])
+const HTMLElement = globalThis.HTMLElement || (null as unknown as (typeof window)['HTMLElement'])
 
 export type DeprecatedFormat = 'auto' | 'micro' | 'elapsed'
 export type ResolvedFormat = 'duration' | 'relative' | 'datetime'
@@ -11,7 +11,12 @@ const emptyDuration = new Duration()
 const microEmptyDuration = new Duration(0, 0, 0, 0, 0, 1)
 
 export class RelativeTimeUpdatedEvent extends Event {
-  constructor(public oldText: string, public newText: string, public oldTitle: string, public newTitle: string) {
+  constructor(
+    public oldText: string,
+    public newText: string,
+    public oldTitle: string,
+    public newTitle: string,
+  ) {
     super('relative-time-updated', {bubbles: true, composed: true})
   }
 }


### PR DESCRIPTION
`npm run build` refused to proceed building without this.

I think the issue is because some eslint module is not properly locked down to a particular version. It would be even better to not have linting as a dependency to the build.