### PR TITLE
Adds flag to optionally hide title attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ So, a relative date phrase is used for up to a month and then the actual date is
 | `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | <sup>***</sup>                   |
 | `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | <sup>****</sup>                  |
 | `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
-| `noTitle`      | `no-title`       | `'boolean \| null'`                                                                         | -                                |
+| `noTitle`      | `no-title`       | `'boolean \| undefined'`                                                                    | `undefined`                      |
 
 <sup>*</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'` or `'micro'`, `'short'` if the format is `'relative'` or `'datetime'`, otherwise it will be `'long'`.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ So, a relative date phrase is used for up to a month and then the actual date is
 | `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | <sup>***</sup>                   |
 | `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | <sup>****</sup>                  |
 | `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
+| `hideTitle`    | `hide-title`     | `boolean \| null`                                                                           | -                                |
 
 <sup>*</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'` or `'micro'`, `'short'` if the format is `'relative'` or `'datetime'`, otherwise it will be `'long'`.
 
@@ -267,6 +268,10 @@ For dates outside of the specified `threshold`, the formatting of the date can b
 ##### lang
 
 Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang). Relative Time will use this to provide an applicable language to the `Intl` APIs. If the individual element does not have a `lang` attribute then it will traverse upwards in the tree to find the closest element that does, or default the lang to `en`.
+
+##### hideTitle (`boolean`, default: `undefined`)
+
+Passing in `hide-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so hiding the title allows a user to create a custom accessible version of a tooltip if one is desired.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/W
 
 ##### noTitle (`boolean`, default: `undefined`)
 
-Passing in `no-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so no adding a title attribute allows a user to create a custom, accessible tooltip if one is desired.
+Passing in `no-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so not adding a title attribute allows a user to create a custom, accessible tooltip if one is desired.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ So, a relative date phrase is used for up to a month and then the actual date is
 | `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | <sup>***</sup>                   |
 | `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | <sup>****</sup>                  |
 | `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
-| `hideTitle`    | `hide-title`     | `boolean \| null`                                                                           | -                                |
+| `noTitle`      | `no-title`       | `boolean \| null`                                                                           | -                                |
 
 <sup>*</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'` or `'micro'`, `'short'` if the format is `'relative'` or `'datetime'`, otherwise it will be `'long'`.
 
@@ -269,9 +269,9 @@ For dates outside of the specified `threshold`, the formatting of the date can b
 
 Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang). Relative Time will use this to provide an applicable language to the `Intl` APIs. If the individual element does not have a `lang` attribute then it will traverse upwards in the tree to find the closest element that does, or default the lang to `en`.
 
-##### hideTitle (`boolean`, default: `undefined`)
+##### noTitle (`boolean`, default: `undefined`)
 
-Passing in `hide-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so hiding the title allows a user to create a custom accessible version of a tooltip if one is desired.
+Passing in `no-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so no adding a title attribute allows a user to create a custom, accessible tooltip if one is desired.
 
 ## Browser Support
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ So, a relative date phrase is used for up to a month and then the actual date is
 | `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | <sup>***</sup>                   |
 | `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | <sup>****</sup>                  |
 | `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
-| `noTitle`      | `no-title`       | `'boolean \| undefined'`                                                                    | `undefined`                      |
+| `noTitle`      | `no-title`       | `-`                                                                                         | `-`                              |
 
 <sup>*</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'` or `'micro'`, `'short'` if the format is `'relative'` or `'datetime'`, otherwise it will be `'long'`.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ So, a relative date phrase is used for up to a month and then the actual date is
 | `month`        | `month`          | `'numeric'\|'2-digit'\|'short'\|'long'\|'narrow'\|undefined`                                | <sup>***</sup>                   |
 | `year`         | `year`           | `'numeric'\|'2-digit'\|undefined`                                                           | <sup>****</sup>                  |
 | `timeZoneName` | `time-zone-name` | `'long'\|'short'\|'shortOffset'\|'longOffset'` `\|'shortGeneric'\|'longGeneric'\|undefined` | `undefined`                      |
-| `noTitle`      | `no-title`       | `boolean \| null`                                                                           | -                                |
+| `noTitle`      | `no-title`       | `'boolean \| null'`                                                                         | -                                |
 
 <sup>*</sup>: If unspecified, `formatStyle` will return `'narrow'` if `format` is `'elapsed'` or `'micro'`, `'short'` if the format is `'relative'` or `'datetime'`, otherwise it will be `'long'`.
 
@@ -269,9 +269,9 @@ For dates outside of the specified `threshold`, the formatting of the date can b
 
 Lang is a [built-in global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang). Relative Time will use this to provide an applicable language to the `Intl` APIs. If the individual element does not have a `lang` attribute then it will traverse upwards in the tree to find the closest element that does, or default the lang to `en`.
 
-##### noTitle (`boolean`, default: `undefined`)
+##### noTitle
 
-Passing in `no-title="true"` will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so not adding a title attribute allows a user to create a custom, accessible tooltip if one is desired.
+Adding the `no-title` attribute will remove the `title` attribute from the `<relative-time>` element. The `title` attribute is inaccessible to screen reader and keyboard users, so not adding a title attribute allows a user to create a custom, accessible tooltip if one is desired.
 
 ## Browser Support
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,6 +22,13 @@
   </p>
 
   <p>
+    Hide title attribute:
+    <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" hour="numeric" minute="2-digit" second="2-digit" hide-title="true">
+      Jan 1 1970
+    </relative-time>
+  </p>
+
+  <p>
     Customised options:
     <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" weekday="narrow" year="2-digit" month="narrow" day="numeric" hour="numeric" minute="2-digit" second="2-digit">
       Jan 1 1970
@@ -185,8 +192,8 @@
     </relative-time>
   </p>
 
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
+  <script type="module" src="../dist/index.js"></script>
+  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
   <script>
     document.body.addEventListener('relative-time-updated', event => {
       console.log('event from', event.target, event)

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,7 +24,7 @@
   <p>
     No title attribute:
     <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" hour="numeric" minute="2-digit" second="2-digit"
-      no-title="true">
+      no-title>
       Jan 1 1970
     </relative-time>
   </p>

--- a/examples/index.html
+++ b/examples/index.html
@@ -192,8 +192,8 @@
     </relative-time>
   </p>
 
-  <script type="module" src="../dist/index.js"></script>
-  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
+  <!-- <script type="module" src="../dist/index.js"></script> -->
+  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
   <script>
     document.body.addEventListener('relative-time-updated', event => {
       console.log('event from', event.target, event)

--- a/examples/index.html
+++ b/examples/index.html
@@ -22,7 +22,7 @@
   </p>
 
   <p>
-    Hide title attribute:
+    No title attribute:
     <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" hour="numeric" minute="2-digit" second="2-digit"
       no-title="true">
       Jan 1 1970
@@ -193,8 +193,8 @@
     </relative-time>
   </p>
 
-  <script type="module" src="../dist/index.js"></script>
-  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
+  <!-- <script type="module" src="../dist/index.js"></script> -->
+  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
   <script>
     document.body.addEventListener('relative-time-updated', event => {
       console.log('event from', event.target, event)

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,7 +23,8 @@
 
   <p>
     Hide title attribute:
-    <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" hour="numeric" minute="2-digit" second="2-digit" hide-title="true">
+    <relative-time datetime="1970-01-01T00:00:00.000Z" format="datetime" hour="numeric" minute="2-digit" second="2-digit"
+      no-title="true">
       Jan 1 1970
     </relative-time>
   </p>
@@ -192,8 +193,8 @@
     </relative-time>
   </p>
 
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
+  <script type="module" src="../dist/index.js"></script>
+  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
   <script>
     document.body.addEventListener('relative-time-updated', event => {
       console.log('event from', event.target, event)

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -107,6 +107,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       'precision',
       'format',
       'format-style',
+      'hide-title',
       'datetime',
       'lang',
       'title',
@@ -382,6 +383,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     this.setAttribute('format-style', value)
   }
 
+  get hideTitle(): boolean {
+    return this.getAttribute('hide-title') === 'true'
+  }
+
   get datetime() {
     return this.getAttribute('datetime') || ''
   }
@@ -431,7 +436,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       return
     }
     const now = Date.now()
-    if (!this.#customTitle) {
+    if (!this.#customTitle && !this.hideTitle) {
       newTitle = this.#getFormattedTitle(date) || ''
       if (newTitle) this.setAttribute('title', newTitle)
     }

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -387,7 +387,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return this.hasAttribute('no-title')
   }
 
-  set noTitle(value: boolean | null) {
+  set noTitle(value: boolean | undefined) {
     this.setAttribute('no-title', value?.toString() || '')
   }
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -384,7 +384,11 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   get noTitle(): boolean {
-    return this.hasAttribute('no-title') && this.getAttribute('no-title') === 'true'
+    return this.hasAttribute('no-title')
+  }
+
+  set noTitle(value: boolean | null) {
+    this.setAttribute('no-title', value?.toString() || '')
   }
 
   get datetime() {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -388,7 +388,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   set noTitle(value: boolean | undefined) {
-    this.toggleAttribute('no-title')
+    this.toggleAttribute('no-title', value)
   }
 
   get datetime() {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -388,7 +388,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   set noTitle(value: boolean | undefined) {
-    this.setAttribute('no-title', value?.toString() || '')
+    this.toggleAttribute('no-title')
   }
 
   get datetime() {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -107,7 +107,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       'precision',
       'format',
       'format-style',
-      'hide-title',
+      'no-title',
       'datetime',
       'lang',
       'title',
@@ -383,8 +383,8 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     this.setAttribute('format-style', value)
   }
 
-  get hideTitle(): boolean {
-    return this.getAttribute('hide-title') === 'true'
+  get noTitle(): boolean {
+    return this.hasAttribute('no-title') && this.getAttribute('no-title') === 'true'
   }
 
   get datetime() {
@@ -436,7 +436,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       return
     }
     const now = Date.now()
-    if (!this.#customTitle && !this.hideTitle) {
+    if (!this.#customTitle && !this.noTitle) {
       newTitle = this.#getFormattedTitle(date) || ''
       if (newTitle) this.setAttribute('title', newTitle)
     }

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -83,7 +83,7 @@ suite('relative-time', function () {
     assert.equal(el.getAttribute('title'), text)
   })
 
-  test('does not set title if no-title=true', async () => {
+  test('does not set title if no-title attribute is present', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date().toISOString())
     el.setAttribute('no-title', '')

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -83,6 +83,22 @@ suite('relative-time', function () {
     assert.equal(el.getAttribute('title'), text)
   })
 
+  test('does not set title if hide-title=true', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date().toISOString())
+    el.setAttribute('hide-title', true)
+    await Promise.resolve()
+    assert.equal(el.getAttribute('title'), null)
+  })
+
+  test('sets title if hide-title=false', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date().toISOString())
+    el.setAttribute('hide-title', false)
+    await Promise.resolve()
+    assert.ok(el.getAttribute('title'))
+  })
+
   test('shadowDOM reflects textContent with invalid date', async () => {
     const el = document.createElement('relative-time')
     el.textContent = 'A date string'

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -83,18 +83,18 @@ suite('relative-time', function () {
     assert.equal(el.getAttribute('title'), text)
   })
 
-  test('does not set title if hide-title=true', async () => {
+  test('does not set title if no-title=true', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date().toISOString())
-    el.setAttribute('hide-title', true)
+    el.setAttribute('no-title', true)
     await Promise.resolve()
     assert.equal(el.getAttribute('title'), null)
   })
 
-  test('sets title if hide-title=false', async () => {
+  test('sets title if no-title=false', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date().toISOString())
-    el.setAttribute('hide-title', false)
+    el.setAttribute('no-title', false)
     await Promise.resolve()
     assert.ok(el.getAttribute('title'))
   })

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -86,17 +86,9 @@ suite('relative-time', function () {
   test('does not set title if no-title=true', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date().toISOString())
-    el.setAttribute('no-title', true)
+    el.setAttribute('no-title', '')
     await Promise.resolve()
     assert.equal(el.getAttribute('title'), null)
-  })
-
-  test('sets title if no-title=false', async () => {
-    const el = document.createElement('relative-time')
-    el.setAttribute('datetime', new Date().toISOString())
-    el.setAttribute('no-title', false)
-    await Promise.resolve()
-    assert.ok(el.getAttribute('title'))
   })
 
   test('shadowDOM reflects textContent with invalid date', async () => {


### PR DESCRIPTION
Related to https://github.com/github/accessibility-audits/issues/5633 & https://github.com/github/accessibility-audits/issues/5524.

Adds a flag to optionally hide the inaccessible `title` attribute. We will use this in the Primer components so we can add an accessible Tooltip element instead for interactive elements.