### PR TITLE
fix: Move `noTitle` conditional.

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -440,9 +440,9 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       return
     }
     const now = Date.now()
-    if (!this.#customTitle && !this.noTitle) {
+    if (!this.#customTitle) {
       newTitle = this.#getFormattedTitle(date) || ''
-      if (newTitle) this.setAttribute('title', newTitle)
+      if (newTitle && !this.noTitle) this.setAttribute('title', newTitle)
     }
 
     const duration = elapsedTime(date, this.precision, now)


### PR DESCRIPTION
Calculate the new title, just don’t update the `title` attribute. This makes the `'relative-time-updated'` event fire, even if `noTitle` is set.