### PR TITLE
Correctly count month durations relative to the end of longer months

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -153,16 +153,23 @@ export function roundToSingleUnit(duration: Duration, {relativeTo = Date.now()}:
 
   // Resolve calendar dates
   const currentYear = relativeTo.getFullYear()
-  let currentMonth = relativeTo.getMonth()
+  const currentMonth = relativeTo.getMonth()
   const currentDate = relativeTo.getDate()
   if (days >= 27 || years + months + days) {
+    const newMonthDate = new Date(relativeTo)
+    newMonthDate.setDate(1)
+    newMonthDate.setMonth(currentMonth + months * sign + 1)
+    newMonthDate.setDate(0)
+    const monthDateCorrection = Math.max(0, currentDate - newMonthDate.getDate())
+
     const newDate = new Date(relativeTo)
     newDate.setFullYear(currentYear + years * sign)
+    newDate.setDate(currentDate - monthDateCorrection)
     newDate.setMonth(currentMonth + months * sign)
-    newDate.setDate(currentDate + days * sign)
+    newDate.setDate(currentDate - monthDateCorrection + days * sign)
     const yearDiff = newDate.getFullYear() - relativeTo.getFullYear()
     const monthDiff = newDate.getMonth() - relativeTo.getMonth()
-    const daysDiff = Math.abs(Math.round((Number(newDate) - Number(relativeTo)) / 86400000))
+    const daysDiff = Math.abs(Math.round((Number(newDate) - Number(relativeTo)) / 86400000)) + monthDateCorrection
     const monthsDiff = Math.abs(yearDiff * 12 + monthDiff)
     if (daysDiff < 27) {
       if (days >= 6) {
@@ -180,7 +187,6 @@ export function roundToSingleUnit(duration: Duration, {relativeTo = Date.now()}:
       years = yearDiff * sign
     }
     if (months || years) days = 0
-    currentMonth = relativeTo.getMonth()
   }
   if (years) months = 0
 

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -367,6 +367,9 @@ suite('duration', function () {
       ['-P55D', [-1, 'month'], {relativeTo: '2023-02-27T22:22:57Z'}],
       ['-P65D', [-3, 'month'], {relativeTo: '2023-02-28T22:22:57Z'}],
       ['-P75D', [-3, 'month'], {relativeTo: '2023-03-09T22:22:57Z'}],
+      ['P1M', [1, 'month'], {relativeTo: '2024-05-31T00:00:00Z'}],
+      ['-P1M', [-1, 'month'], {relativeTo: '2024-05-31T00:00:00Z'}],
+      ['-P3M', [-3, 'month'], {relativeTo: '2023-05-30T00:00:00Z'}],
       [
         'P8M',
         [8, 'month'],
@@ -396,6 +399,8 @@ suite('duration', function () {
         },
       ],
       ['P1M1D', [1, 'month'], {relativeTo: new Date('2022-12-01T00:00:00Z')}],
+      ['P1M1D', [2, 'month'], {relativeTo: new Date('2023-01-31T00:00:00Z')}],
+      ['P1M30D', [2, 'month'], {relativeTo: new Date('2023-01-31T00:00:00Z')}],
       [
         'P9M20DT25H',
         [9, 'month'],
@@ -478,14 +483,14 @@ suite('duration', function () {
       ],
     ])
     for (const [input, [val, unit], opts] of relativeTests) {
-      test(`getRelativeTimeUnit(${input}) === [${val}, ${unit}]`, () => {
+      test(`getRelativeTimeUnit(${input}${opts ? `, ${JSON.stringify(opts)}` : ''}) === [${val}, ${unit}]`, () => {
         assert.deepEqual(
           getRelativeTimeUnit(Duration.from(input), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
           [val, unit],
         )
       })
       if (opts?.relativeTo) continue
-      test(`getRelativeTimeUnit(-${input}) === [-${val}, ${unit}]`, () => {
+      test(`getRelativeTimeUnit(-${input}${opts ? `, ${JSON.stringify(opts)}` : ''}) === [-${val}, ${unit}]`, () => {
         assert.deepEqual(
           getRelativeTimeUnit(Duration.from(`-${input}`), opts || {relativeTo: new Date('2023-07-01T00:00:00')}),
           [-val, unit],

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -482,6 +482,24 @@ suite('relative-time', function () {
       assert.equal(time.shadowRoot.textContent, '4 months ago')
     })
 
+    test('rewrites from last few days of month to smaller last month', async () => {
+      freezeTime(new Date(2024, 4, 31))
+      const time = document.createElement('relative-time')
+      time.setAttribute('tense', 'past')
+      time.setAttribute('datetime', '2024-04-30T00:00:00Z')
+      await Promise.resolve()
+      assert.equal(time.shadowRoot.textContent, 'last month')
+    })
+
+    test('rewrites from last few days of month to smaller previous month', async () => {
+      freezeTime(new Date(2024, 4, 31))
+      const time = document.createElement('relative-time')
+      time.setAttribute('tense', 'past')
+      time.setAttribute('datetime', '2024-02-29T00:00:00Z')
+      await Promise.resolve()
+      assert.equal(time.shadowRoot.textContent, '3 months ago')
+    })
+
     test('micro formats years', async () => {
       const datetime = new Date()
       datetime.setFullYear(datetime.getFullYear() - 10)


### PR DESCRIPTION
Right now relative month time frames are not calculated correctly if the relative duration would put it past the end of a shorter month causing #281, e.g. something like "May 31 minus 1 month" (see <https://github.com/github/relative-time-element/issues/281#issuecomment-2142961052> for more explanation of why)

This PR fixes these sorts of anomalies by correcting "May 31 minus 1 month" to be equal to "April 30" rather than "May 1"

I've added test cases as well to affirm this new expected behavior (and made duration test cases work when two test cases have equivalent duration but relativeTo date is different). Please look through the test cases, though, to make sure these are all intended consequences

Fixes #281 