### PR TITLE
ensure #updating doesnt hang updates

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -193,6 +193,13 @@
     </relative-time>
   </p>
 
+  <p>
+    Lazily added datetime via setAttribute
+    <relative-time id="lazy" tense="past">
+      This will display in one second.
+    </relative-time>
+  </p>
+
   <!-- <script type="module" src="../dist/index.js"></script> -->
   <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
   <script>
@@ -203,6 +210,9 @@
     document.getElementById('dynamic2').date = new Date(Date.now() - 30000)
     document.getElementById('dynamic3').date = new Date(Date.now() + 5000)
     document.getElementById('dynamic4').date = new Date()
+    setTimeout(() => {
+      document.getElementById('lazy').setAttribute('datetime', new Date().toJSON())
+    }, 1000)
   </script>
 </body>
 </html>

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -426,6 +426,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       this.#updating = (async () => {
         await Promise.resolve()
         this.update()
+        this.#updating = false
       })()
     }
   }
@@ -472,7 +473,6 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     } else {
       dateObserver.unobserve(this)
     }
-    this.#updating = false
   }
 }
 

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -70,6 +70,15 @@ suite('relative-time', function () {
     assert.equal(counter, 1)
   })
 
+  test('calls update even after nullish datetime', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', '')
+    await new Promise(resolve => setTimeout(resolve, 10))
+    el.setAttribute('datetime', new Date().toISOString())
+    await Promise.resolve()
+    assert(el.shadowRoot.textContent.length > 0, 'should have set time, but textContent is empty')
+  })
+
   test('sets title back to default if removed', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date().toISOString())


### PR DESCRIPTION
@cheshire137 exposed an interesting timing flaw in #289. If you set a null/empty datetime the `#updating` Promise (which tries to batch updates) can be left as a resolved promise due to an early return in `update()`.

The last line of `update()` sets `#updating` to false:

https://github.com/github/relative-time-element/blob/15ca61e1992f39f242aa4de0b35c14ce76062990/src/relative-time-element.ts#L475-L476

However if `update()` is called while the `date` is `null` then it hits this early return:

https://github.com/github/relative-time-element/blob/15ca61e1992f39f242aa4de0b35c14ce76062990/src/relative-time-element.ts#L438-L441

That early return never sets `#updating = false`, and so when the date is set again we skip a call to `update()` as it looks like we're in an update batch already:

https://github.com/github/relative-time-element/blob/15ca61e1992f39f242aa4de0b35c14ce76062990/src/relative-time-element.ts#L425-L430

The solution is quite simple: update should always set `#updating = false` when returning. So one could assume the following diff would be a good patch:

```diff
    if (typeof Intl === 'undefined' || !Intl.DateTimeFormat || !date) {
      this.#renderRoot.textContent = oldText
+     this.#updating = false
      return
    }
```

While this would solve the problem it doesn't make for very maintainable code as each new early return would also need to add this or reintroduce the bug. So instead we should colocate all `#updating` assignments, which should have happened in the first place. Hence the patch is:

```diff
    if (!this.#updating && !(attrName === 'title' && this.#customTitle)) {
      this.#updating = (async () => {
        await Promise.resolve()
        this.update()
+       this.#updating = false
      })()
    }
```


Fixes #289.