### PR TITLE
Overhaul duration calculation functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .js,.ts && tsc --noEmit",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "eslint . --ext .js,.ts --fix",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "bundle": "esbuild --bundle dist/index.js --keep-names --outfile=dist/bundle.js --format=esm",
     "build": "tsc && npm run bundle && npm run manifest",

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -1,4 +1,12 @@
-import {Duration, elapsedTime, getRelativeTimeUnit, isDuration, roundToSingleUnit, Unit, unitNames} from './duration.js'
+import {
+  Duration,
+  elapsedTime,
+  relativeTime,
+  isDuration,
+  roundBalancedToSingleUnit,
+  Unit,
+  unitNames,
+} from './duration.js'
 const HTMLElement = globalThis.HTMLElement || (null as unknown as typeof window['HTMLElement'])
 
 export type DeprecatedFormat = 'auto' | 'micro' | 'elapsed'
@@ -156,7 +164,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     const tense = this.tense
     let empty = emptyDuration
     if (format === 'micro') {
-      duration = roundToSingleUnit(duration)
+      duration = roundBalancedToSingleUnit(duration)
       empty = microEmptyDuration
       if ((this.tense === 'past' && duration.sign !== -1) || (this.tense === 'future' && duration.sign !== 1)) {
         duration = microEmptyDuration
@@ -171,15 +179,16 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return duration.abs().toLocaleString(locale, {style})
   }
 
-  #getRelativeFormat(duration: Duration): string {
+  #getRelativeFormat(date: Date): string {
     const relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
       numeric: 'auto',
       style: this.formatStyle,
     })
+    let [int, unit] = relativeTime(date, this.precision)
     const tense = this.tense
-    if (tense === 'future' && duration.sign !== 1) duration = emptyDuration
-    if (tense === 'past' && duration.sign !== -1) duration = emptyDuration
-    const [int, unit] = getRelativeTimeUnit(duration)
+    if ((tense === 'future' && int < 0) || (tense === 'past' && int > 0)) {
+      ;[int, unit] = [0, 'second']
+    }
     if (unit === 'second' && int < 10) {
       return relativeFormat.format(0, this.precision === 'millisecond' ? 'second' : this.precision)
     }
@@ -452,7 +461,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     if (format === 'duration') {
       newText = this.#getDurationFormat(duration)
     } else if (format === 'relative') {
-      newText = this.#getRelativeFormat(duration)
+      newText = this.#getRelativeFormat(date)
     } else {
       newText = this.#getDateTimeFormat(date)
     }

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -441,7 +441,7 @@ suite('relative-time', function () {
       time.setAttribute('tense', 'past')
       time.setAttribute('datetime', '2023-01-01T00:00:00Z')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '11 years ago')
+      assert.equal(time.shadowRoot.textContent, '10 years ago')
     })
 
     test('rewrites from now past datetime to minutes ago', async () => {
@@ -488,7 +488,7 @@ suite('relative-time', function () {
       time.setAttribute('tense', 'past')
       time.setAttribute('datetime', '2023-06-01T00:00:00Z')
       await Promise.resolve()
-      assert.equal(time.shadowRoot.textContent, '4 months ago')
+      assert.equal(time.shadowRoot.textContent, '3 months ago')
     })
 
     test('rewrites from last few days of month to smaller last month', async () => {
@@ -1167,7 +1167,7 @@ suite('relative-time', function () {
         datetime: '2022-11-13T15:46:00.000Z',
         format: 'relative',
         precision: 'month',
-        expected: 'this month',
+        expected: 'next month',
       },
       {
         datetime: '2022-11-13T15:46:00.000Z',
@@ -1263,25 +1263,25 @@ suite('relative-time', function () {
       {
         datetime: '2022-12-03T15:46:00.000Z',
         format: 'duration',
-        expected: '1 month, 10 days, 1 hour',
+        expected: '1 month, 9 days, 1 hour',
       },
       {
         datetime: '2022-12-03T15:46:00.000Z',
         format: 'duration',
         precision: 'minute',
-        expected: '1 month, 10 days, 1 hour',
+        expected: '1 month, 9 days, 1 hour',
       },
       {
         datetime: '2022-12-03T15:46:00.000Z',
         format: 'duration',
         precision: 'day',
-        expected: '1 month, 10 days',
+        expected: '1 month, 9 days',
       },
       {
         datetime: '2022-12-03T15:46:00.000Z',
         format: 'duration',
         tense: 'future',
-        expected: '1 month, 10 days, 1 hour',
+        expected: '1 month, 9 days, 1 hour',
       },
       {
         datetime: '2022-12-03T15:46:00.000Z',
@@ -1336,25 +1336,25 @@ suite('relative-time', function () {
       {
         datetime: '2024-10-24T14:46:00.000Z',
         format: 'duration',
-        expected: '2 years, 11 days',
+        expected: '2 years',
       },
       {
         datetime: '2024-10-24T14:46:00.000Z',
         format: 'duration',
         precision: 'minute',
-        expected: '2 years, 11 days',
+        expected: '2 years',
       },
       {
         datetime: '2024-10-24T14:46:00.000Z',
         format: 'duration',
         precision: 'day',
-        expected: '2 years, 11 days',
+        expected: '2 years',
       },
       {
         datetime: '2024-10-24T14:46:00.000Z',
         format: 'duration',
         tense: 'future',
-        expected: '2 years, 11 days',
+        expected: '2 years',
       },
       {
         datetime: '2024-10-24T14:46:00.000Z',
@@ -1786,19 +1786,19 @@ suite('relative-time', function () {
       {
         datetime: '2020-10-24T14:46:00.000Z',
         format: 'duration',
-        expected: '2 years, 10 days',
+        expected: '2 years',
       },
       {
         datetime: '2020-10-24T14:46:00.000Z',
         format: 'duration',
         precision: 'minute',
-        expected: '2 years, 10 days',
+        expected: '2 years',
       },
       {
         datetime: '2020-10-24T14:46:00.000Z',
         format: 'duration',
         precision: 'day',
-        expected: '2 years, 10 days',
+        expected: '2 years',
       },
       {
         datetime: '2020-10-24T14:46:00.000Z',
@@ -1810,7 +1810,7 @@ suite('relative-time', function () {
         datetime: '2020-10-24T14:46:00.000Z',
         format: 'duration',
         tense: 'past',
-        expected: '2 years, 10 days',
+        expected: '2 years',
       },
       {
         reference: '2023-03-23T12:03:00.000Z',
@@ -1958,13 +1958,13 @@ suite('relative-time', function () {
         expected: '1y',
       },
       {
-        datetime: '2024-03-31T14:46:00.000Z',
+        datetime: '2024-09-23T14:46:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '2y',
+        expected: '1y',
       },
       {
-        datetime: '2024-04-01T14:46:00.000Z',
+        datetime: '2024-09-24T14:46:00.000Z',
         tense: 'future',
         format: 'micro',
         expected: '2y',
@@ -2130,7 +2130,7 @@ suite('relative-time', function () {
       {
         datetime: '2021-10-30T14:46:00.000Z',
         format: 'elapsed',
-        expected: '11m 29d',
+        expected: '11m 24d',
       },
       {
         datetime: '2021-10-30T14:46:00.000Z',
@@ -2139,7 +2139,7 @@ suite('relative-time', function () {
         expected: '11m',
       },
       {
-        datetime: '2021-10-29T14:46:00.000Z',
+        datetime: '2021-10-24T14:46:00.000Z',
         format: 'elapsed',
         expected: '1y',
       },
@@ -2482,11 +2482,11 @@ suite('relative-time', function () {
         datetime: '2024-03-01T12:00:00.000Z',
         tense: 'future',
         format: 'micro',
-        expected: '2y',
+        expected: '1y',
       },
       {
         reference: '2021-04-24T12:00:00.000Z',
-        datetime: '2023-02-01T12:00:00.000Z',
+        datetime: '2023-04-21T12:00:00.000Z',
         tense: 'future',
         format: 'micro',
         expected: '2y',


### PR DESCRIPTION
The current implementation of the relative date display appears to be brittle and actually being broken, for instance with this PR's date being 2 Dec 2024, the date 28 Jan 2024 is being very wrongly displayed as "9 days ago".

![image](https://github.com/user-attachments/assets/c565116b-cc43-46e4-8051-266ded565742)

This pull request is an attempt to rebuild the computations from the ground up so as to be more consistent and robust:

- The relative display format is now implemented using a separate function, taking into account the actual dates in question rather than relying on the information-stripped duration.
- The duration display format has a new implementation and no longer relies on a reference date.
- Functions `applyDuration` and `elapsedTime` now give consistent results.

Some semantics had to be changed and so I expect questions and probably some alterations to the details.