### PR TITLE
fix: wrap Intl.<>() calls in try/catch

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -82,11 +82,13 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   #updating: false | Promise<void> = false
 
   get #lang() {
-    return (
-      this.closest('[lang]')?.getAttribute('lang') ||
-      this.ownerDocument.documentElement.getAttribute('lang') ||
-      'default'
-    )
+    const lang = this.closest('[lang]')?.getAttribute('lang') ||
+      this.ownerDocument.documentElement.getAttribute('lang')
+    try {
+      return new Intl.Locale(lang ?? '').toString()
+    } catch {
+      return 'default'
+    }
   }
 
   #renderRoot: Node = this.shadowRoot ? this.shadowRoot : this.attachShadow ? this.attachShadow({mode: 'open'}) : this
@@ -120,27 +122,14 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   //
   // Returns a formatted time String.
   #getFormattedTitle(date: Date): string | undefined {
-    let dateTimeFormat
-    try {
-      dateTimeFormat = new Intl.DateTimeFormat(this.#lang, {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZoneName: 'short',
-      })
-    } catch (_e) {
-      dateTimeFormat = new Intl.DateTimeFormat('default', {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZoneName: 'short',
-      })
-    }
-    return dateTimeFormat.format(date)
+    return new Intl.DateTimeFormat(this.#lang, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    }).format(date)
   }
 
   #resolveFormat(duration: Duration): ResolvedFormat {
@@ -185,19 +174,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getRelativeFormat(duration: Duration): string {
-    let relativeFormat
-
-    try {
-      relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
-        numeric: 'auto',
-        style: this.formatStyle,
-      })
-    } catch (_e) {
-      relativeFormat = new Intl.RelativeTimeFormat('default', {
-        numeric: 'auto',
-        style: this.formatStyle,
-      })
-    }
+    const relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
+      numeric: 'auto',
+      style: this.formatStyle,
+    })
 
     const tense = this.tense
     if (tense === 'future' && duration.sign !== 1) duration = emptyDuration
@@ -210,30 +190,16 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getDateTimeFormat(date: Date): string {
-    let formatter
-    try {
-      formatter = new Intl.DateTimeFormat(this.#lang, {
-        second: this.second,
-        minute: this.minute,
-        hour: this.hour,
-        weekday: this.weekday,
-        day: this.day,
-        month: this.month,
-        year: this.year,
-        timeZoneName: this.timeZoneName,
-      })
-    } catch (_e) {
-      formatter = new Intl.DateTimeFormat('default', {
-        second: this.second,
-        minute: this.minute,
-        hour: this.hour,
-        weekday: this.weekday,
-        day: this.day,
-        month: this.month,
-        year: this.year,
-        timeZoneName: this.timeZoneName,
-      })
-    }
+    const formatter = new Intl.DateTimeFormat(this.#lang, {
+      second: this.second,
+      minute: this.minute,
+      hour: this.hour,
+      weekday: this.weekday,
+      day: this.day,
+      month: this.month,
+      year: this.year,
+      timeZoneName: this.timeZoneName,
+    })
     return `${this.prefix} ${formatter.format(date)}`.trim()
   }
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -120,14 +120,27 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   //
   // Returns a formatted time String.
   #getFormattedTitle(date: Date): string | undefined {
-    return new Intl.DateTimeFormat(this.#lang, {
-      day: 'numeric',
-      month: 'short',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZoneName: 'short',
-    }).format(date)
+    let dateTimeFormat
+    try {
+      dateTimeFormat = new Intl.DateTimeFormat(this.#lang, {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZoneName: 'short',
+      })
+    } catch (_e) {
+      dateTimeFormat = new Intl.DateTimeFormat('default', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZoneName: 'short',
+      })
+    }
+    return dateTimeFormat.format(date)
   }
 
   #resolveFormat(duration: Duration): ResolvedFormat {
@@ -172,10 +185,20 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getRelativeFormat(duration: Duration): string {
-    const relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
-      numeric: 'auto',
-      style: this.formatStyle,
-    })
+    let relativeFormat
+
+    try {
+      relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
+        numeric: 'auto',
+        style: this.formatStyle,
+      })
+    } catch (_e) {
+      relativeFormat = new Intl.RelativeTimeFormat('default', {
+        numeric: 'auto',
+        style: this.formatStyle,
+      })
+    }
+
     const tense = this.tense
     if (tense === 'future' && duration.sign !== 1) duration = emptyDuration
     if (tense === 'past' && duration.sign !== -1) duration = emptyDuration
@@ -187,16 +210,30 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getDateTimeFormat(date: Date): string {
-    const formatter = new Intl.DateTimeFormat(this.#lang, {
-      second: this.second,
-      minute: this.minute,
-      hour: this.hour,
-      weekday: this.weekday,
-      day: this.day,
-      month: this.month,
-      year: this.year,
-      timeZoneName: this.timeZoneName,
-    })
+    let formatter
+    try {
+      formatter = new Intl.DateTimeFormat(this.#lang, {
+        second: this.second,
+        minute: this.minute,
+        hour: this.hour,
+        weekday: this.weekday,
+        day: this.day,
+        month: this.month,
+        year: this.year,
+        timeZoneName: this.timeZoneName,
+      })
+    } catch (_e) {
+      formatter = new Intl.DateTimeFormat('default', {
+        second: this.second,
+        minute: this.minute,
+        hour: this.hour,
+        weekday: this.weekday,
+        day: this.day,
+        month: this.month,
+        year: this.year,
+        timeZoneName: this.timeZoneName,
+      })
+    }
     return `${this.prefix} ${formatter.format(date)}`.trim()
   }
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -82,8 +82,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   #updating: false | Promise<void> = false
 
   get #lang() {
-    const lang = this.closest('[lang]')?.getAttribute('lang') ||
-      this.ownerDocument.documentElement.getAttribute('lang')
+    const lang = this.closest('[lang]')?.getAttribute('lang') || this.ownerDocument.documentElement.getAttribute('lang')
     try {
       return new Intl.Locale(lang ?? '').toString()
     } catch {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -178,7 +178,6 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       numeric: 'auto',
       style: this.formatStyle,
     })
-
     const tense = this.tense
     if (tense === 'future' && duration.sign !== 1) duration = emptyDuration
     if (tense === 'past' && duration.sign !== -1) duration = emptyDuration

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -440,7 +440,6 @@ suite('relative-time', function () {
     const element = document.createElement('relative-time')
     element.setAttribute('datetime', now)
     element.setAttribute('lang', 'does-not-exist')
-    assert.doesNotThrow(() => element.attributeChangedCallback('lang', null, null))
 
     await Promise.resolve()
     assert.equal(element.shadowRoot.textContent, 'now')

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -434,6 +434,18 @@ suite('relative-time', function () {
     })
   }
 
+  test('renders correctly when given an invalid lang', async () => {
+    const now = new Date().toISOString()
+
+    const element = document.createElement('relative-time')
+    element.setAttribute('datetime', now)
+    element.setAttribute('lang', 'does-not-exist')
+    assert.doesNotThrow(() => element.attributeChangedCallback('lang', null, null))
+
+    await Promise.resolve()
+    assert.equal(element.shadowRoot.textContent, 'now')
+  })
+
   suite('[tense=past]', function () {
     test('always uses relative dates', async () => {
       freezeTime(new Date(2033, 1, 1))


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/4409

Fixes error thrown when an invalid locale is passed to the `Intl` functions by wrapping it in Try/Catch. When the call fails (locale is invalid), the default locale will be used