### PR TITLE
Make `applyDuration` reversible

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -84,14 +84,35 @@ export class Duration {
   }
 }
 
+const durationApplicationActionsForward = [
+  (r: Date, duration: Duration) => {
+    r.setUTCFullYear(r.getUTCFullYear() + duration.years)
+  },
+  (r: Date, duration: Duration) => {
+    r.setUTCMonth(r.getUTCMonth() + duration.months)
+  },
+  (r: Date, duration: Duration) => {
+    r.setUTCDate(r.getUTCDate() + duration.weeks * 7 + duration.days)
+  },
+  (r: Date, duration: Duration) => {
+    r.setUTCHours(r.getUTCHours() + duration.hours)
+  },
+  (r: Date, duration: Duration) => {
+    r.setUTCMinutes(r.getUTCMinutes() + duration.minutes)
+  },
+  (r: Date, duration: Duration) => {
+    r.setUTCSeconds(r.getUTCSeconds() + duration.seconds)
+  },
+]
+const durationApplicationActionsBackward = [...durationApplicationActionsForward].reverse()
+
 export function applyDuration(date: Date | number, duration: Duration): Date {
   const r = new Date(date)
-  r.setFullYear(r.getFullYear() + duration.years)
-  r.setMonth(r.getMonth() + duration.months)
-  r.setDate(r.getDate() + duration.weeks * 7 + duration.days)
-  r.setHours(r.getHours() + duration.hours)
-  r.setMinutes(r.getMinutes() + duration.minutes)
-  r.setSeconds(r.getSeconds() + duration.seconds)
+  if (duration.sign < 0) {
+    for (const action of durationApplicationActionsBackward) action(r, duration)
+  } else {
+    for (const action of durationApplicationActionsForward) action(r, duration)
+  }
   return r
 }
 

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -84,34 +84,22 @@ export class Duration {
   }
 }
 
-const durationApplicationActionsForward = [
-  (r: Date, duration: Duration) => {
-    r.setUTCFullYear(r.getUTCFullYear() + duration.years)
-  },
-  (r: Date, duration: Duration) => {
-    r.setUTCMonth(r.getUTCMonth() + duration.months)
-  },
-  (r: Date, duration: Duration) => {
-    r.setUTCDate(r.getUTCDate() + duration.weeks * 7 + duration.days)
-  },
-  (r: Date, duration: Duration) => {
-    r.setUTCHours(r.getUTCHours() + duration.hours)
-  },
-  (r: Date, duration: Duration) => {
-    r.setUTCMinutes(r.getUTCMinutes() + duration.minutes)
-  },
-  (r: Date, duration: Duration) => {
-    r.setUTCSeconds(r.getUTCSeconds() + duration.seconds)
-  },
-]
-const durationApplicationActionsBackward = [...durationApplicationActionsForward].reverse()
-
 export function applyDuration(date: Date | number, duration: Duration): Date {
   const r = new Date(date)
   if (duration.sign < 0) {
-    for (const action of durationApplicationActionsBackward) action(r, duration)
+    r.setUTCSeconds(r.getUTCSeconds() + duration.seconds)
+    r.setUTCMinutes(r.getUTCMinutes() + duration.minutes)
+    r.setUTCHours(r.getUTCHours() + duration.hours)
+    r.setUTCDate(r.getUTCDate() + duration.weeks * 7 + duration.days)
+    r.setUTCMonth(r.getUTCMonth() + duration.months)
+    r.setUTCFullYear(r.getUTCFullYear() + duration.years)
   } else {
-    for (const action of durationApplicationActionsForward) action(r, duration)
+    r.setUTCFullYear(r.getUTCFullYear() + duration.years)
+    r.setUTCMonth(r.getUTCMonth() + duration.months)
+    r.setUTCDate(r.getUTCDate() + duration.weeks * 7 + duration.days)
+    r.setUTCHours(r.getUTCHours() + duration.hours)
+    r.setUTCMinutes(r.getUTCMinutes() + duration.minutes)
+    r.setUTCSeconds(r.getUTCSeconds() + duration.seconds)
   }
   return r
 }

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -81,16 +81,19 @@ suite('duration', function () {
   })
 
   suite('applyDuration', function () {
-    const referenceDate = '2022-10-21T16:48:44.104Z'
     const tests = new Set([
-      {input: 'P4Y', expected: '2026-10-21T16:48:44.104Z'},
-      {input: '-P4Y', expected: '2018-10-21T16:48:44.104Z'},
-      {input: '-P3MT5M', expected: '2022-07-21T16:43:44.104Z'},
-      {input: 'P1Y2M3DT4H5M6S', expected: '2023-12-24T20:53:50.104Z'},
-      {input: 'P5W', expected: '2022-11-25T16:48:44.104Z'},
-      {input: '-P5W', expected: '2022-09-16T16:48:44.104Z'},
+      {referenceDate: '2022-10-21T16:48:44.104Z', input: 'P5W', expected: '2022-11-25T16:48:44.104Z'},
+      {referenceDate: '2022-11-25T16:48:44.104Z', input: '-P5W', expected: '2022-10-21T16:48:44.104Z'},
+      {referenceDate: '2022-07-21T16:43:44.104Z', input: 'P3MT5M', expected: '2022-10-21T16:48:44.104Z'},
+      {referenceDate: '2022-10-21T16:48:44.104Z', input: '-P3MT5M', expected: '2022-07-21T16:43:44.104Z'},
+      {referenceDate: '2022-10-21T16:48:44.104Z', input: 'P4Y', expected: '2026-10-21T16:48:44.104Z'},
+      {referenceDate: '2026-10-21T16:48:44.104Z', input: '-P4Y', expected: '2022-10-21T16:48:44.104Z'},
+      {referenceDate: '2022-10-21T16:48:44.104Z', input: 'P1Y2M3DT4H5M6S', expected: '2023-12-24T20:53:50.104Z'},
+      {referenceDate: '2023-12-24T20:53:50.104Z', input: '-P1Y2M3DT4H5M6S', expected: '2022-10-21T16:48:44.104Z'},
+      {referenceDate: '2023-08-15T00:00:00.000Z', input: 'P1Y3M25D', expected: '2024-12-10T00:00:00.000Z'},
+      {referenceDate: '2024-12-10T00:00:00.000Z', input: '-P1Y3M25D', expected: '2023-08-15T00:00:00.000Z'},
     ])
-    for (const {input, expected} of tests) {
+    for (const {referenceDate, input, expected} of tests) {
       test(`${referenceDate} -> ${input} -> ${expected}`, () => {
         assert.equal(applyDuration(new Date(referenceDate), Duration.from(input))?.toISOString(), expected)
       })


### PR DESCRIPTION
(This is part of a set of multiple pull requests looking to overhaul the calculation functions.)

When the duration to be applied is negative, this pull request makes the application order of the components reversed compared to when the duration is positive, so that adding a duration to a date then subtracting the same amount yields the same date.

**Note:** One test is failing on my end from the current upstream code:

```
relative-time > [tense=future] > micro formats years
AssertionError: expected '3y' to equal '2y'
+ expected - actual

- 3y
+ 2y
```

This is caused by the current implementation of `roundToNearestUnit` computing the future date to be in 2027, resulting in a 3-year difference as it only considers the year alone in this case. This will be fixed with a reimplementation of the function in one of my other pull requests.