### PR TITLE
Revert "Declare `relative-element` under React.JSX to fix React 19 compatibility"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,6 @@
         "eslint-plugin-custom-elements": "^0.0.8",
         "eslint-plugin-github": "^4.7.0",
         "typescript": "^5.0.4"
-      },
-      "peerDependencies": {
-        "@types/react": "18 || 19"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1289,13 +1286,6 @@
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
@@ -1307,17 +1297,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -3534,13 +3513,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/custom-elements-manifest": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,6 @@
     "eslint-plugin-github": "^4.7.0",
     "typescript": "^5.0.4"
   },
-  "peerDependencies": {
-    "@types/react": "18 || 19"
-  },
-  "peerDependenciesMeta": {
-    "@types/react": {
-      "optional": true
-    }
-  },
   "eslintIgnore": [
     "dist/"
   ],

--- a/src/relative-time-element-define.ts
+++ b/src/relative-time-element-define.ts
@@ -22,9 +22,6 @@ declare global {
   interface HTMLElementTagNameMap {
     'relative-time': RelativeTimeElement
   }
-}
-
-declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
       ['relative-time']: JSXBase['span'] & Partial<Omit<RelativeTimeElement, keyof HTMLElement>>


### PR DESCRIPTION
Reverts github/relative-time-element#305

These changes turned out to not be compatible with non-react projects (sample test: https://github.com/primer/view_components/pull/3472)
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/f9159fc5-60fe-46ce-97fc-9685e95f77e4" />

Reverting