### PR TITLE
fix: Ensure aria-hidden applies to shadow root

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -200,6 +200,8 @@
     </relative-time>
   </p>
 
+  <h2>With Aria Hidden</h2>
+
   <button class="js-toggle-aria-hidden">
     With aria-hidden
     <relative-time aria-hidden="true" datetime="1970-01-01T00:00:00.000Z">

--- a/examples/index.html
+++ b/examples/index.html
@@ -200,17 +200,17 @@
     </relative-time>
   </p>
 
-  <p>
+
+  <button class="js-toggle-aria-hidden">
     With aria-hidden
-    <relative-time aria-hidden="true" datetime="1970-01-01T00:00:00.000Z" format="datetime">
-      Jan 1 1970
+    <relative-time aria-hidden="true" datetime="1970-01-01T00:00:00.000Z">
     </relative-time>
-  </p>
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
+  </button>
+  <script type="module" src="../dist/index.js"></script>
+  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
   <script>
     document.body.addEventListener('relative-time-updated', event => {
-      console.log('event from', event.target, event)
+      // console.log('event from', event.target, event)
     });
     document.getElementById('dynamic1').date = new Date()
     document.getElementById('dynamic2').date = new Date(Date.now() - 30000)
@@ -219,6 +219,19 @@
     setTimeout(() => {
       document.getElementById('lazy').setAttribute('datetime', new Date().toJSON())
     }, 1000)
+
+
+    const toggleAriaHidden = (event) => {
+      const relativeTimeElement = event.currentTarget.querySelector('relative-time')
+      if (relativeTimeElement.getAttribute('aria-hidden') === 'true') {
+        relativeTimeElement.setAttribute('aria-hidden', 'false')
+      } else {
+        relativeTimeElement.setAttribute('aria-hidden', 'true')
+      }
+    }
+    const button = document.querySelector('.js-toggle-aria-hidden')
+    button.addEventListener('click', toggleAriaHidden)
+
   </script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -200,6 +200,12 @@
     </relative-time>
   </p>
 
+  <p>
+    With aria-hidden
+    <relative-time aria-hidden="true" datetime="1970-01-01T00:00:00.000Z" format="datetime">
+      Jan 1 1970
+    </relative-time>
+  </p>
   <!-- <script type="module" src="../dist/index.js"></script> -->
   <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
   <script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -200,17 +200,17 @@
     </relative-time>
   </p>
 
-
   <button class="js-toggle-aria-hidden">
     With aria-hidden
     <relative-time aria-hidden="true" datetime="1970-01-01T00:00:00.000Z">
     </relative-time>
   </button>
-  <script type="module" src="../dist/index.js"></script>
-  <!-- <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script> -->
+
+  <!-- <script type="module" src="../dist/index.js"></script> -->
+  <script type="module" src="https://unpkg.com/@github/relative-time-element@latest/dist/bundle.js"></script>
   <script>
     document.body.addEventListener('relative-time-updated', event => {
-      // console.log('event from', event.target, event)
+      console.log('event from', event.target, event)
     });
     document.getElementById('dynamic1').date = new Date()
     document.getElementById('dynamic2').date = new Date(Date.now() - 30000)
@@ -219,7 +219,6 @@
     setTimeout(() => {
       document.getElementById('lazy').setAttribute('datetime', new Date().toJSON())
     }, 1000)
-
 
     const toggleAriaHidden = (event) => {
       const relativeTimeElement = event.currentTarget.querySelector('relative-time')
@@ -231,7 +230,6 @@
     }
     const button = document.querySelector('.js-toggle-aria-hidden')
     button.addEventListener('click', toggleAriaHidden)
-
   </script>
 </body>
 </html>

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -202,6 +202,17 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return `${this.prefix} ${formatter.format(date)}`.trim()
   }
 
+  #updateRenderRootContent(content: string | null): void {
+    if (this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true') {
+      const span = document.createElement('span')
+      span.setAttribute('aria-hidden', 'true')
+      span.textContent = content
+      ;(this.#renderRoot as Element).replaceChildren(span)
+    } else {
+      this.#renderRoot.textContent = content
+    }
+  }
+
   #onRelativeTimeUpdated: ((event: RelativeTimeUpdatedEvent) => void) | null = null
   get onRelativeTimeUpdated() {
     return this.#onRelativeTimeUpdated
@@ -460,17 +471,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     }
 
     if (newText) {
-      if (this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true') {
-        const span = document.createElement('span')
-        span.setAttribute('aria-hidden', 'true')
-        span.textContent = newText
-        ;(this.#renderRoot as Element).replaceChildren(span)
-      } else {
-        this.#renderRoot.textContent = newText
-      }
+      this.#updateRenderRootContent(newText)
     } else if (this.shadowRoot === this.#renderRoot && this.textContent) {
       // Ensure invalid dates fall back to lightDOM text content
-      this.#renderRoot.textContent = this.textContent
+      this.#updateRenderRootContent(this.textContent)
     }
 
     if (newText !== oldText || newTitle !== oldTitle) {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -459,10 +459,14 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     }
 
     if (newText) {
-      this.#renderRoot.textContent = newText
+      if (this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true') {
+        (this.#renderRoot as Element).innerHTML = `<span aria-hidden="true">${newText}</span>`;
+      } else {
+        this.#renderRoot.textContent = newText;
+      }
     } else if (this.shadowRoot === this.#renderRoot && this.textContent) {
       // Ensure invalid dates fall back to lightDOM text content
-      this.#renderRoot.textContent = this.textContent
+      this.#renderRoot.textContent = this.textContent;
     }
 
     if (newText !== oldText || newTitle !== oldTitle) {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -112,6 +112,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       'datetime',
       'lang',
       'title',
+      'aria-hidden',
     ]
   }
 
@@ -460,13 +461,16 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
 
     if (newText) {
       if (this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true') {
-        (this.#renderRoot as Element).innerHTML = `<span aria-hidden="true">${newText}</span>`;
+        const span = document.createElement('span')
+        span.setAttribute('aria-hidden', 'true')
+        span.textContent = newText
+        ;(this.#renderRoot as Element).replaceChildren(span)
       } else {
-        this.#renderRoot.textContent = newText;
+        this.#renderRoot.textContent = newText
       }
     } else if (this.shadowRoot === this.#renderRoot && this.textContent) {
       // Ensure invalid dates fall back to lightDOM text content
-      this.#renderRoot.textContent = this.textContent;
+      this.#renderRoot.textContent = this.textContent
     }
 
     if (newText !== oldText || newTitle !== oldTitle) {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1903,7 +1903,7 @@ suite('relative-time', function () {
       await Promise.resolve()
 
       assert.isNull(time.shadowRoot.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
-      assert.isNull(time.querySelector('span'), 'Expected no span to be present')
+      assert.isNull(time.shadowRoot.querySelector('span'), 'Expected no span to be present')
     })
   })
 

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1902,7 +1902,7 @@ suite('relative-time', function () {
       time.setAttribute('datetime', now)
       await Promise.resolve()
 
-      assert.isNull(time.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
+      assert.isNull(time.shadowRoot.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
       assert.isNull(time.querySelector('span'), 'Expected no span to be present')
     })
   })

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -122,7 +122,7 @@ suite('relative-time', function () {
     assert.notEqual(nextDisplay, display)
   })
 
-  test('all observedAttributes have getters', async () => {
+  test('all observedAttributes have getters)', async () => {
     const members = [
       ...Object.getOwnPropertyNames(RelativeTimeElement.prototype).map(n =>
         n.replace(/([A-Z])/g, c => `-${c.toLowerCase()}`),
@@ -130,6 +130,7 @@ suite('relative-time', function () {
       ...Object.getOwnPropertyNames(HTMLElement.prototype),
     ]
     const observedAttributes = new Set(RelativeTimeElement.observedAttributes)
+    observedAttributes.delete('aria-hidden') // Standard HTML attribute, no need for custom getter
     for (const member of members) observedAttributes.delete(member)
     assert.empty([...observedAttributes], 'observedAttributes that arent class members')
   })
@@ -1870,6 +1871,40 @@ suite('relative-time', function () {
         assert.equal(time.shadowRoot.textContent, expected)
       })
     }
+  })
+
+  suite('[aria-hidden]', async () => {
+    test('[aria-hidden="true"] applies to shadow root', async () => {
+      const now = new Date().toISOString()
+      const time = document.createElement('relative-time')
+      time.setAttribute('datetime', now)
+      time.setAttribute('aria-hidden', 'true')
+      await Promise.resolve()
+
+      const span = time.shadowRoot.querySelector('span')
+      assert.equal(span.getAttribute('aria-hidden'), 'true')
+    })
+
+    test('[aria-hidden="false"] applies to shadow root', async () => {
+      const now = new Date().toISOString()
+      const time = document.createElement('relative-time')
+      time.setAttribute('datetime', now)
+      time.setAttribute('aria-hidden', 'false')
+      await Promise.resolve()
+
+      assert.isNull(time.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
+      assert.isNull(time.querySelector('span'), 'Expected no span to be present')
+    })
+
+    test('no aria-hidden applies to shadow root', async () => {
+      const now = new Date().toISOString()
+      const time = document.createElement('relative-time')
+      time.setAttribute('datetime', now)
+      await Promise.resolve()
+
+      assert.isNull(time.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
+      assert.isNull(time.querySelector('span'), 'Expected no span to be present')
+    })
   })
 
   suite('legacy formats', function () {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -122,7 +122,7 @@ suite('relative-time', function () {
     assert.notEqual(nextDisplay, display)
   })
 
-  test('all observedAttributes have getters)', async () => {
+  test('all observedAttributes have getters', async () => {
     const members = [
       ...Object.getOwnPropertyNames(RelativeTimeElement.prototype).map(n =>
         n.replace(/([A-Z])/g, c => `-${c.toLowerCase()}`),

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1893,7 +1893,7 @@ suite('relative-time', function () {
       await Promise.resolve()
 
       assert.isNull(time.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
-      assert.isNull(time.querySelector('span'), 'Expected no span to be present')
+      assert.isNull(time.shadowRoot.querySelector('span'), 'Expected no span to be present')
     })
 
     test('no aria-hidden applies to shadow root', async () => {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1892,7 +1892,7 @@ suite('relative-time', function () {
       time.setAttribute('aria-hidden', 'false')
       await Promise.resolve()
 
-      assert.isNull(time.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
+      assert.isNull(time.shadowRoot.querySelector('[aria-hidden]'), 'Expected no aria-hidden to be present')
       assert.isNull(time.shadowRoot.querySelector('span'), 'Expected no span to be present')
     })
 


### PR DESCRIPTION
Relates to: https://github.com/github/pull-requests/issues/17192

## Problem

When `aria-hidden="true"` is set on an relative-time element, the attribute doesn't always persist into the shadow root. As a result, even when `aria-hidden` is applied, the text rendered in relative-time can end up composing the accessible name (instead of being hidden from the AT tree).

## Solution

This makes update to render the text content within `aria-hidden="true"`, when `aria-hidden="true"` is set on the shadow root. 

## Demo

Before (no sound):

https://github.com/user-attachments/assets/5a049c15-8ec7-4a7f-be6e-97c3b149f389

video description: I'm on the demo page with the developer console open. The markup shows `aria-hidden` being toggled between true and false relative-time upon pressing the button. I switch to the accessibility tree mode. I see the accessible name for the button remains: `With aria-hidden on Dec 31, 1969` despite toggling.

After (no sound):

https://github.com/user-attachments/assets/b662b53c-11c2-49b4-98b5-8bf002b04b0f

video description: I'm on the demo page with the developer console open. The markup shows `aria-hidden` being toggled between true and false relative-time upon pressing the button. I switch to the accessibility tree mode. I see the accessible name for the button toggle between: `With aria-hidden on Dec 31, 1969` and `With aria-hidden` as we'd expect.

